### PR TITLE
Add Mineo (Docomo) APN settings

### DIFF
--- a/userspace/files/serviceproviders.xml
+++ b/userspace/files/serviceproviders.xml
@@ -7553,7 +7553,7 @@ conceived.
 				<username>mineo@k-opti.com</username>
 				<password>mineo</password>
 			</apn>
-			</gsm>
+		</gsm>
 	</provider>
 	<provider primary="false">
 		<name>b-mobile</name>

--- a/userspace/files/serviceproviders.xml
+++ b/userspace/files/serviceproviders.xml
@@ -7543,19 +7543,6 @@ conceived.
 		</gsm>
 	</provider>
 	<provider primary="false">
-		<name>Mineo (Docomo)</name>
-		<gsm>
-			<network-id mcc="440" mnc="10"/>
-			<apn value="mineo-d.jp">
-				<plan type="prepaid"/>
-				<usage type="internet"/>
-				<name>mineo-d.jp</name>
-				<username>mineo@k-opti.com</username>
-				<password>mineo</password>
-			</apn>
-		</gsm>
-	</provider>
-	<provider primary="false">
 		<name>b-mobile</name>
 		<gsm>
 			<network-id mcc="440" mnc="10"/>
@@ -7647,6 +7634,13 @@ conceived.
 				<plan type="postpaid"/>
 				<usage type="internet"/>
 				<name>mopera U</name>
+			</apn>
+			<apn value="mineo-d.jp">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>mineo-d.jp</name>
+				<username>mineo@k-opti.com</username>
+				<password>mineo</password>
 			</apn>
 		</gsm>
 	</provider>

--- a/userspace/files/serviceproviders.xml
+++ b/userspace/files/serviceproviders.xml
@@ -7542,19 +7542,19 @@ conceived.
 			</apn>
 		</gsm>
 	</provider>
-        <provider primary="false">
-                <name>Mineo (Docomo)</name>
-                <gsm>
-                        <network-id mcc="440" mnc="10"/>
-                        <apn value="mineo-d.jp">
-                                <plan type="prepaid"/>
-                                <usage type="internet"/>
-                                <name>mineo-d.jp</name>
-                                <username>mineo@k-opti.com</username>
-                                <password>mineo</password>
-                        </apn>
-                </gsm>
-        </provider>
+	<provider primary="false">
+		<name>Mineo (Docomo)</name>
+		<gsm>
+			<network-id mcc="440" mnc="10"/>
+			<apn value="mineo-d.jp">
+				<plan type="prepaid"/>
+				<usage type="internet"/>
+				<name>mineo-d.jp</name>
+				<username>mineo@k-opti.com</username>
+				<password>mineo</password>
+			</apn>
+			</gsm>
+	</provider>
 	<provider primary="false">
 		<name>b-mobile</name>
 		<gsm>

--- a/userspace/files/serviceproviders.xml
+++ b/userspace/files/serviceproviders.xml
@@ -7542,6 +7542,19 @@ conceived.
 			</apn>
 		</gsm>
 	</provider>
+        <provider primary="false">
+                <name>Mineo (Docomo)</name>
+                <gsm>
+                        <network-id mcc="440" mnc="10"/>
+                        <apn value="mineo-d.jp">
+                                <plan type="prepaid"/>
+                                <usage type="internet"/>
+                                <name>mineo-d.jp</name>
+                                <username>mineo@k-opti.com</username>
+                                <password>mineo</password>
+                        </apn>
+                </gsm>
+        </provider>
 	<provider primary="false">
 		<name>b-mobile</name>
 		<gsm>


### PR DESCRIPTION
I would like to add the APN settings of the Japanese MVNO Mineo.

Settings can be found here (only Japanese :-( ): https://support.mineo.jp/setup/guide/android_network.html

Mineo is offering plans for the three major Japanese providers (au, Docomo and Softbank). Their API settings differ in MCC, MNC and APN name. 
I am using the Docomo plan (MCC 440, MNC 10, APN mineo-d.jp) (see also here https://en.wikipedia.org/wiki/Mobile_Network_Codes_in_ITU_region_4xx_(Asia)#Japan_%E2%80%93_JP).

Confirmed to be working on comma three.

(I noticed that only the first entry in the list with matching MCC/MNC is used for connection. When I moved the Mineo entry below the next one in the list (bmobile), no LTE connection could be established, since only the connection to b-mobile was used. We might need a way to specify which APN to use(?))