### PR TITLE
mount /dsp and /firmware read only

### DIFF
--- a/userspace/files/fstab
+++ b/userspace/files/fstab
@@ -1,5 +1,5 @@
-/dev/disk/by-label/dsp /dsp auto
-/dev/disk/by-partlabel/modem_a /firmware auto
+/dev/disk/by-label/dsp /dsp auto ro
+/dev/disk/by-partlabel/modem_a /firmware auto ro
 /dev/disk/by-partlabel/userdata /data auto discard,nosuid,nodev,nofail 0 0
 /dev/nvme0n1 /data/media auto discard,nosuid,nodev,nofail,x-systemd.device-timeout=5s 0 0
 tmpfs /var tmpfs rw,nosuid,nodev,size=128M,mode=755 0 0


### PR DESCRIPTION
First part of #11. Android mounts both of these as RO.

There's also systemd mount targets for these partitions in `agnos-base_0.0.1.deb` that should be removed.