### PR TITLE
Support build_system.sh on M1 Mac

### DIFF
--- a/build_system.sh
+++ b/build_system.sh
@@ -38,8 +38,8 @@ docker build -f Dockerfile.agnos -t agnos-builder $DIR
 
 # Create filesystem ext4 image
 echo "Creating empty filesystem"
-fallocate -l $ROOTFS_IMAGE_SIZE $ROOTFS_IMAGE
-mkfs.ext4 $ROOTFS_IMAGE > /dev/null
+docker run --rm --mount type=bind,source=$BUILD_DIR,target=$BUILD_DIR -it agnos-builder fallocate -l $ROOTFS_IMAGE_SIZE $ROOTFS_IMAGE
+docker run --rm --mount type=bind,source=$BUILD_DIR,target=$BUILD_DIR -it agnos-builder mkfs.ext4 $ROOTFS_IMAGE
 
 # Mount filesystem
 echo "Mounting empty filesystem"

--- a/build_system.sh
+++ b/build_system.sh
@@ -45,7 +45,7 @@ docker start build_system_helper || docker run -d \
   -t ubuntu:20.04 bash
 
 docker exec -t build_system_helper apt update
-docker exec -t build_system_helper apt install -y img2simg sudo
+docker exec -t build_system_helper apt install -y img2simg
 
 # Create filesystem ext4 image
 echo "Creating empty filesystem"
@@ -55,8 +55,8 @@ docker exec -it build_system_helper mkfs.ext4 $ROOTFS_IMAGE
 # Mount filesystem
 echo "Mounting empty filesystem"
 mkdir -p $ROOTFS_DIR
-docker exec -t build_system_helper sudo umount -l $ROOTFS_DIR || true
-docker exec -t build_system_helper sudo mount $ROOTFS_IMAGE $ROOTFS_DIR
+docker exec -t build_system_helper umount -l $ROOTFS_DIR || true
+docker exec -t build_system_helper mount $ROOTFS_IMAGE $ROOTFS_DIR
 
 # Extract image
 echo "Extracting docker image"
@@ -81,7 +81,6 @@ cd $DIR
 # Unmount image
 echo "Unmount filesystem"
 docker exec -it build_system_helper umount -l $ROOTFS_DIR
-# sudo umount -l $ROOTFS_DIR
 
 # Sparsify
 echo "Sparsify image"

--- a/build_system.sh
+++ b/build_system.sh
@@ -36,14 +36,10 @@ echo "Building image"
 export DOCKER_CLI_EXPERIMENTAL=enabled
 docker build -f Dockerfile.agnos -t agnos-builder $DIR
 
-# Create a temporary container in which to do some platform-specific work so that Mac can build too
-docker start build_system_helper || docker run -d \
-  --privileged \
+# Create a temporary container in which to run linux-specific calls (for Mac support)
+docker start build_system_helper || docker run -d --privileged \
   --mount type=bind,source=$BUILD_DIR,target=$BUILD_DIR \
-  --mount type=bind,source=/tmp/script.sh,target=/tmp/script.sh \
-  --name build_system_helper \
-  -t ubuntu:20.04 bash
-
+  --name build_system_helper -t ubuntu:20.04 bash
 docker exec -t build_system_helper apt update
 docker exec -t build_system_helper apt install -y img2simg
 

--- a/build_system.sh
+++ b/build_system.sh
@@ -26,7 +26,7 @@ fi
 
 # TODO: this needs to be re-done sometimes
 # Register qemu multiarch if not done
-if [ ! -f $DIR/.qemu_registered ] && [ "$(uname -p)" != "aarch64" ]; then
+if [ ! -f $DIR/.qemu_registered ] && [ "$(uname -p)" != "aarch64" ] && [ "$(uname -m)" != "arm64" ]; then
   docker run --rm --privileged multiarch/qemu-user-static:register
   touch $DIR/.qemu_registered
 fi


### PR DESCRIPTION
This PR only focuses on build_system.sh

# build_system.sh

The existing check (uname -p) does not work. the check I added (uname -m) might be sufficient for whatever environment warranted the addition of the first, but for now, this PR adds a check for M1 which works.

```
keyvan@Keyvans-MacBook-Air ~ % uname -p
arm
keyvan@Keyvans-MacBook-Air ~ % uname -m
arm64
```


The actual run of `build_system` ended for me on:

```
Creating empty filesystem
./build_system.sh: line 41: fallocate: command not found
```

So then I made the next commit which creates the empty filesystem inside the docker container.

Here I also removed the /dev/null piping so that in case the thing is giving feedback or asking if you want to overwrite the user isn't stuck wondering what's going on.

Then we get stuck at:

```
Mounting empty filesystem
umount: illegal option -- l
usage: umount [-fv] [-t fstypelist] special | node
       umount -a[fv] [-h host] [-t fstypelist]
mount: You must specify a filesystem type with -t.
```

Because the BSD/Mac umount does not have a -l (show labels). It's at this point I realized probably the rest of the work needs to happen in a container anyway because we lack most of these subsequent disk mounting commands....

So that is what I did in the remainder of the script and it seems to have worked.

![image](https://user-images.githubusercontent.com/175305/147374340-ce89be2d-b823-4e83-abb3-d6c26511fc31.png)

