### PR TITLE
power drop monitor improvements

### DIFF
--- a/userspace/usr/comma/power_drop_monitor.py
+++ b/userspace/usr/comma/power_drop_monitor.py
@@ -56,8 +56,13 @@ def update_param(shutdown):
   except Exception:
     print("Failed to update LastControlledShutdown param")
 
+def printk(msg):
+  with open('/dev/kmsg', 'w') as kmsg:
+    kmsg.write(f"<3>[power drop monitor] {msg}\n")
+  print(msg)
+
 def perform_controlled_shutdown():
-  print("Power alert received! If voltage still low after 100ms, shutting down...")
+  printk("Power alert received! If voltage still low after 100ms, shutting down...")
   prev_screen_power = get_screen_power()
   set_screen_power(False)
 
@@ -67,24 +72,28 @@ def perform_controlled_shutdown():
     time.sleep(0.01)
 
   if read_voltage_mV() > ALERT_VOLTAGE_THRESHOLD_mV:
-    print("Voltage restored. Not shutting down!")
+    printk("Voltage restored. Not shutting down!")
     update_param(shutdown=False)
     set_screen_power(prev_screen_power)
     return
 
+  printk("Shutdown")
   update_param(shutdown=True)
 
-  # Send a signal to loggerd that it's time to clean up
-  os.system("pkill -SIGPWR loggerd")
+  printk("Unmount nvme")
+  os.system("umount -l /dev/nvme0")
+  # TODO: turn off nvme regulator. Currently no userspace control over this
+
+  printk("Killing services")
+  os.system("pkill -9 loggerd")
   os.system("pkill -9 _ui")
   os.system("pkill -9 modeld")
   os.system("pkill -9 camerad")
 
-  # Wait for loggerd to exit
-  while os.system("pgrep loggerd") == 0:
-    time.sleep(0.01)
+  printk("Sync /data")
+  os.system("sync --file-system /data")
+  printk("Sync done. Halting")
 
-  os.sync()
   os.system("halt -f")
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Do not wait for loggerd to exit cleanly. It won't since it tries to write to the NVME
- Only sync `/data`
- Lazy nvme unmount to prevent kernel panic after the `halt -f`