### PR TITLE
Set GBM debug level

### DIFF
--- a/userspace/files/weston.service
+++ b/userspace/files/weston.service
@@ -20,6 +20,7 @@ ExecStart=/bin/bash -c "sleep 4 && \
                         chown -R comma: $XDG_RUNTIME_DIR && \
                         mkdir -p /data/misc/display || true && \
                         echo 0 > /data/misc/display/sdm_dbg_cfg.txt || true && \
+                        echo 0 > /data/misc/display/gbm_dbg_cfg.txt || true && \
                         /usr/bin/weston --idle-time=0 --tty=1 --config=/usr/comma/weston.ini"
 KillSignal=SIGKILL
 


### PR DESCRIPTION
Silences a bunch of INFO message when starting the ui. There are a lot when using the no copy NV12 textures.

```
GBM_INFO::msmgbm_bo_import_gbm_buf(1161):: MAP table is empty
GBM_INFO::msmgbm_bo_import_gbm_buf(1164)::Registered fd=20 to table
GBM_INFO::get_size(371):: VENUS_BUF_SIZE=4804608, computed for Width=1928, Height=1208
GBM_INFO::get_size(371):: VENUS_BUF_SIZE=4804608, computed for Width=1928, Height=1208
GBM_INFO::msmgbm_get_metadata(2588)::metadata_fd=-1 and hence valid meta info cannot be retrieved
GBM_INFO::msmgbm_get_metadata(2589)::We will make a graceful exit
GBM_INFO::msmgbm_get_metadata(2588)::metadata_fd=-1 and hence valid meta info cannot be retrieved
GBM_INFO::msmgbm_get_metadata(2589)::We will make a graceful exit
GBM_INFO::msmgbm_bo_cpu_map(1796)::This is not optimized path for cpu bo map
GBM_INFO::msmgbm_get_metadata(2588)::metadata_fd=-1 and hence valid meta info cannot be retrieved
GBM_INFO::msmgbm_get_metadata(2589)::We will make a graceful exit
GBM_INFO::msmgbm_bo_cpu_map(1796)::This is not optimized path for cpu bo map
GBM_INFO::msmgbm_get_metadata(2588)::metadata_fd=-1 and hence valid meta info cannot be retrieved
GBM_INFO::msmgbm_get_metadata(2589)::We will make a graceful exit
```