### PR TITLE
Wait for partitions before starting rmt_storage service

### DIFF
--- a/userspace/debs/agnos-wlan_0.0.1.deb
+++ b/userspace/debs/agnos-wlan_0.0.1.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:56980ff55a0571308fb86224c7908b3b233720fd9e9277784544386b465560a9
-size 113652

--- a/userspace/debs/agnos-wlan_0.0.2.deb
+++ b/userspace/debs/agnos-wlan_0.0.2.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b62fc6592375550c1e2eb304d4bc3a173c51060bdbc482b1544b9321cdaf8262
+size 113744

--- a/userspace/hardware_setup.sh
+++ b/userspace/hardware_setup.sh
@@ -5,7 +5,7 @@ cd /tmp/agnos/debs
 apt-get -o Dpkg::Options::="--force-overwrite" install -yq \
   ./agnos-base.deb \
   ./agnos-display_0.0.1.deb \
-  ./agnos-wlan_0.0.1.deb
+  ./agnos-wlan_0.0.2.deb
 
 # Install 16.04 version of libjson-c2
 cd /tmp

--- a/userspace/usr/comma/wait_for_file.sh
+++ b/userspace/usr/comma/wait_for_file.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+until [ -e $1 ]
+do
+  sleep 1
+done
+


### PR DESCRIPTION
The issue this fixes is that `rmt_storage` needs to have these symlinks existing before starting, which are populated by udev and `/etc/udev/scripts/automountsdcard.sh`:

- /dev/block/bootdevice/by-name/modemst1
- /dev/block/bootdevice/by-name/modemst2
- /dev/block/bootdevice/by-name/fsc
- /dev/block/bootdevice/by-name/fsg

Not sure if there's a cleaner way than this, but couldn't figure out how to easily wait for a file to exist before starting a service other than this bash script called in `ExecStartPre=`