### PR TITLE
Start sshd early

### DIFF
--- a/userspace/files/ssh-param-watcher.service
+++ b/userspace/files/ssh-param-watcher.service
@@ -1,10 +1,9 @@
 [Unit]
 Description=SSH param watcher
-After=multi-user.target
 
 [Service]
 Type=oneshot
 ExecStart=/usr/comma/set_ssh.sh
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=rescue.target


### PR DESCRIPTION
Having both `After=multi-user.target` and `WantedBy=multi-user.target` doesn't sound like a good idea:
https://unix.stackexchange.com/questions/693485/after-multi-user-target-and-others-not-working-in-a-systemd-service

Also, the rescue target is nicer, since that make s sure sshd is up in case any of the runlevel 2 stuff fails.