### PR TITLE
optimise system image using simg2dontcare

### DIFF
--- a/internal/ota_push.sh
+++ b/internal/ota_push.sh
@@ -58,12 +58,8 @@ SAS_EXPIRY=$(date -u '+%Y-%m-%dT%H:%M:%SZ' -d '+1 hour')
 DATA_SAS_TOKEN=$(az storage container generate-sas --as-user --auth-mode login --account-name $DATA_ACCOUNT --name $DATA_CONTAINER --https-only --permissions wr --expiry $SAS_EXPIRY --output tsv)
 
 # Liftoff!
-process_file "system"
-process_file "boot"
-process_file "abl"
-process_file "xbl"
-process_file "xbl_config"
-process_file "devcfg"
-process_file "aop"
+for name in $(cat $OTA_JSON | jq -r ".[] .name"); do
+  process_file $name
+done
 
 echo "Done!"

--- a/internal/package_ota.sh
+++ b/internal/package_ota.sh
@@ -72,7 +72,7 @@ EOF
 
   if [ "$SPARSE" == "true" ]; then
     echo "Optimizing $NAME..."
-    local OPTIMIZED_FILE=/tmp/$NAME-optimized.img
+    local OPTIMIZED_FILE=$TMP_DIR/$NAME-optimized.img
     $TOOLS_DIR/simg2dontcare.py $FILE $OPTIMIZED_FILE
 
     echo "Hashing optimized $NAME..."

--- a/internal/package_ota.sh
+++ b/internal/package_ota.sh
@@ -41,7 +41,7 @@ process_file() {
   local HASH_RAW=$HASH
   if [ "$NAME" == "system" ]; then
     echo "Converting system to raw..."
-    local FILE_RAW=/tmp/system.img.raw
+    local FILE_RAW=$TMP_DIR/system.img.raw
     simg2img $FILE $FILE_RAW
 
     echo "Hashing system raw..."

--- a/internal/package_ota.sh
+++ b/internal/package_ota.sh
@@ -8,6 +8,7 @@ TMP_DIR="/tmp/agnos-builder-tmp"
 OUTPUT_DIR="$ROOT/output"
 OTA_OUTPUT_DIR="$OUTPUT_DIR/ota"
 FIRMWARE_DIR="$ROOT/agnos-firmware"
+TOOLS_DIR="$ROOT/tools"
 
 AGNOS_UPDATE_URL=${AGNOS_UPDATE_URL:-https://commadist.azureedge.net/agnosupdate}
 AGNOS_STAGING_UPDATE_URL=${AGNOS_STAGING_UPDATE_URL:-https://commadist.azureedge.net/agnosupdate-staging}
@@ -40,11 +41,16 @@ process_file() {
     SIZE=$(wc -c < $FILE_RAW)
     echo "  $HASH_RAW ($SIZE bytes) (raw)"
 
-
     # echo "Creating system casync files"
     # casync make --compression=xz --store $OTA_OUTPUT_DIR/system-$HASH_RAW $OTA_OUTPUT_DIR/system-$HASH_RAW.caibx $FILE_RAW
 
     rm $FILE_RAW
+
+    echo "Optimizing system..."
+    local OPTIMIZED_IMAGE_FILE=/tmp/system-optimized.img
+    $TOOLS_DIR/simg2dontcare.py $FILE $OPTIMIZED_IMAGE_FILE
+    mv $FILE ${FILE%.img}-original.img
+    mv $OPTIMIZED_IMAGE_FILE $FILE
   fi
 
   echo "Compressing $NAME..."

--- a/internal/package_ota.sh
+++ b/internal/package_ota.sh
@@ -80,7 +80,7 @@ EOF
     echo "  $HASH_OPTIMIZED (optimized)"
 
     echo "Compressing optimized $NAME..."
-    local OPTIMIZED_FILENAME=$NAME-optimized-$HASH_OPTIMIZED.img.xz
+    local OPTIMIZED_FILENAME=$NAME-$HASH_RAW-optimized.img.xz
     local OPTIMIZED_ARCHIVE=$OTA_OUTPUT_DIR/$OPTIMIZED_FILENAME
     xz -vc $OPTIMIZED_FILE > $OPTIMIZED_ARCHIVE
 

--- a/internal/package_ota.sh
+++ b/internal/package_ota.sh
@@ -30,6 +30,17 @@ process_file() {
   local SIZE=$(wc -c < $FILE)
   echo "  $HASH ($SIZE bytes)"
 
+  if [ "$NAME" == "system" ]; then
+    echo "Optimizing system..."
+    local OPTIMIZED_FILE=/tmp/system-optimized.img
+    $TOOLS_DIR/simg2dontcare.py $FILE $OPTIMIZED_FILE
+    mv $FILE ${FILE%.img}-original.img
+    mv $OPTIMIZED_FILE $FILE
+
+    echo "Hashing optimized system..."
+    HASH=$(sha256sum $FILE | cut -c 1-64)
+  fi
+
   local HASH_RAW=$HASH
   if [ "$NAME" == "system" ]; then
     echo "Converting system to raw..."
@@ -45,12 +56,6 @@ process_file() {
     # casync make --compression=xz --store $OTA_OUTPUT_DIR/system-$HASH_RAW $OTA_OUTPUT_DIR/system-$HASH_RAW.caibx $FILE_RAW
 
     rm $FILE_RAW
-
-    echo "Optimizing system..."
-    local OPTIMIZED_IMAGE_FILE=/tmp/system-optimized.img
-    $TOOLS_DIR/simg2dontcare.py $FILE $OPTIMIZED_IMAGE_FILE
-    mv $FILE ${FILE%.img}-original.img
-    mv $OPTIMIZED_IMAGE_FILE $FILE
   fi
 
   echo "Compressing $NAME..."

--- a/internal/package_ota.sh
+++ b/internal/package_ota.sh
@@ -25,21 +25,18 @@ process_file() {
   local FULL_CHECK=${4:-true}
   local HAS_AB=${5:-true}
 
-  echo "Hashing $NAME..."
-  local HASH=$(sha256sum $FILE | cut -c 1-64)
-  local SIZE=$(wc -c < $FILE)
-  echo "  $HASH ($SIZE bytes)"
-
   if [ "$NAME" == "system" ]; then
     echo "Optimizing system..."
     local OPTIMIZED_FILE=/tmp/system-optimized.img
     $TOOLS_DIR/simg2dontcare.py $FILE $OPTIMIZED_FILE
     mv $FILE ${FILE%.img}-original.img
     mv $OPTIMIZED_FILE $FILE
-
-    echo "Hashing optimized system..."
-    HASH=$(sha256sum $FILE | cut -c 1-64)
   fi
+
+  echo "Hashing $NAME..."
+  local HASH=$(sha256sum $FILE | cut -c 1-64)
+  local SIZE=$(wc -c < $FILE)
+  echo "  $HASH ($SIZE bytes)"
 
   local HASH_RAW=$HASH
   if [ "$NAME" == "system" ]; then

--- a/tools/simg2dontcare.py
+++ b/tools/simg2dontcare.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+import struct
+from enum import IntEnum
+
+# https://android.googlesource.com/platform/system/core/+/master/libsparse/sparse_format.h
+class ChunkType(IntEnum):
+  RAW = 0xCAC1
+  FILL = 0xCAC2
+  DONT_CARE = 0xCAC3
+  CRC32 = 0xCAC4
+
+ChunkHeader = struct.Struct("<2H2I")
+
+
+def process_image(input_image: str, output_image: str) -> None:
+  with open(input_image, "rb") as inf, open(output_image, "wb") as outf:
+    dat = inf.read(28)
+    outf.write(dat)
+
+    header = struct.unpack("<I4H4I", dat)
+
+    magic = header[0]
+    major_version = header[1]
+    minor_version = header[2]
+    file_hdr_sz = header[3]
+    chunk_hdr_sz = header[4]
+    total_chunks = header[7]
+    image_checksum = header[8]
+
+    assert magic == 0xED26FF3A
+    assert major_version == 1 and minor_version == 0
+    assert file_hdr_sz == 28
+    assert chunk_hdr_sz == 12
+
+    for i in range(1, total_chunks+1):
+      header_bin = inf.read(12)
+
+      header = ChunkHeader.unpack(header_bin)
+      chunk_type = ChunkType(header[0])
+      chunk_sz = header[2]
+      total_sz = header[3]
+      data_sz = total_sz - 12
+
+      # replace fill 0s with DONT_CARE chunks
+      if chunk_type == ChunkType.FILL:
+        assert data_sz == 4
+        fill_bin = inf.read(4)
+        fill = struct.unpack("<I", fill_bin)[0]
+        if fill == 0:
+          # https://coral.googlesource.com/img2simg/+/refs/heads/master/libsparse/output_file.c#351
+          dat = ChunkHeader.pack(ChunkType.DONT_CARE, 0, chunk_sz, ChunkHeader.size)
+          outf.write(dat)
+          continue
+        else:
+          inf.seek(inf.tell() - data_sz)
+
+      # pass through other chunk types
+      outf.write(header_bin)
+      dat = inf.read(data_sz)
+      outf.write(dat)
+
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(description="Replace FILL 0 chunks in a sparse image with DONT_CARE chunks",
+                                   formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+  parser.add_argument("input_image", nargs="?", help="Input sparse image")
+  parser.add_argument("output_image", nargs="?", help="Output sparse image")
+  args = parser.parse_args(sys.argv[1:])
+
+  if args.input_image is None or args.output_image is None:
+    parser.print_help()
+    exit(1)
+
+  process_image(args.input_image, args.output_image)


### PR DESCRIPTION
Generate an additional "optimized" image for any sparse partition. Adds `url_optimized` and `hash_optimized` properties to manifest.

As the optimized image requires the partition to be erased first, the original image is preserved and still uploaded so that we don't break existing flash/openpilot updater.

split out from https://github.com/commaai/agnos-builder/pull/165