### PR TITLE
note that tmux prefix key is backtick in MOTD

### DIFF
--- a/userspace/motd/20-quickstart
+++ b/userspace/motd/20-quickstart
@@ -4,6 +4,7 @@ cat << 'EOF'
 
 Here are some useful commands:
   Enter the tmux session where the comma service runs
+  (note: tmux prefix key has been configured to backtick)
     └── tmux a
 
   Install Ubuntu packages


### PR DESCRIPTION
configured away from the default of ctrl-b