### PR TITLE
hostname with serial number

### DIFF
--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -160,6 +160,9 @@ RUN cd /tmp/ && \
 COPY ./userspace/files/linux-headers-4.9.103+_4.9.103+-1_arm64.deb /tmp/
 RUN dpkg -i /tmp/linux-headers-4.9.103+_4.9.103+-1_arm64.deb
 
+# use hostname from kernel everywhere (nomrally transient)
+RUN rm /etc/hostname && ln -s /proc/sys/kernel/hostname /etc/hostname
+
 # Weston with hacked touch rotate and color correction
 COPY ./userspace/files/weston /usr/bin/weston
 COPY ./userspace/files/gl-renderer.so /usr/lib/arm-linux-gnueabihf/weston

--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -160,9 +160,6 @@ RUN cd /tmp/ && \
 COPY ./userspace/files/linux-headers-4.9.103+_4.9.103+-1_arm64.deb /tmp/
 RUN dpkg -i /tmp/linux-headers-4.9.103+_4.9.103+-1_arm64.deb
 
-# use hostname from kernel everywhere (nomrally transient)
-RUN rm /etc/hostname && ln -s /proc/sys/kernel/hostname /etc/hostname
-
 # Weston with hacked touch rotate and color correction
 COPY ./userspace/files/weston /usr/bin/weston
 COPY ./userspace/files/gl-renderer.so /usr/lib/arm-linux-gnueabihf/weston

--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -16,7 +16,7 @@ RUN set -xe
 
 ENV USERNAME=comma
 ENV PASSWD=comma
-ENV HOST=tici
+ENV HOST=comma
 
 # Base system setup
 RUN echo "resolvconf resolvconf/linkify-resolvconf boolean false" | debconf-set-selections

--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -45,7 +45,7 @@ cp $DIR/agnos-kernel-sdm845/out/arch/arm64/boot/Image.gz-dtb .
 $TOOLS/mkbootimg \
   --kernel Image.gz-dtb \
   --ramdisk /dev/null \
-  --cmdline "console=ttyMSM0,115200n8 quiet loglevel=3 earlycon=msm_geni_serial,0xA84000 androidboot.hardware=qcom androidboot.console=ttyMSM0 video=DSI-1:1080x2160@60e ehci-hcd.park=3 lpm_levels.sleep_disabled=1 service_locator.enable=1 androidboot.selinux=permissive firmware_class.path=/lib/firmware/updates net.ifnames=0 dyndbg=\"\"" \
+  --cmdline "console=ttyMSM0,115200n8 quiet loglevel=3 earlycon=msm_geni_serial,0xA84000 androidboot.hardware=qcom androidboot.console=ttyMSM0 video=DSI-1:1080x2160@60e ehci-hcd.park=3 lpm_levels.sleep_disabled=1 service_locator.enable=1 androidboot.selinux=permissive firmware_class.path=/lib/firmware/updates net.ifnames=0 systemd.hostname=tici dyndbg=\"\"" \
   --pagesize 4096 \
   --base 0x80000000 \
   --kernel_offset 0x8000 \

--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -45,7 +45,7 @@ cp $DIR/agnos-kernel-sdm845/out/arch/arm64/boot/Image.gz-dtb .
 $TOOLS/mkbootimg \
   --kernel Image.gz-dtb \
   --ramdisk /dev/null \
-  --cmdline "console=ttyMSM0,115200n8 quiet loglevel=3 earlycon=msm_geni_serial,0xA84000 androidboot.hardware=qcom androidboot.console=ttyMSM0 video=DSI-1:1080x2160@60e ehci-hcd.park=3 lpm_levels.sleep_disabled=1 service_locator.enable=1 androidboot.selinux=permissive firmware_class.path=/lib/firmware/updates net.ifnames=0 systemd.hostname=tici dyndbg=\"\"" \
+  --cmdline "console=ttyMSM0,115200n8 quiet loglevel=3 earlycon=msm_geni_serial,0xA84000 androidboot.hardware=qcom androidboot.console=ttyMSM0 video=DSI-1:1080x2160@60e ehci-hcd.park=3 lpm_levels.sleep_disabled=1 service_locator.enable=1 androidboot.selinux=permissive firmware_class.path=/lib/firmware/updates net.ifnames=0 dyndbg=\"\"" \
   --pagesize 4096 \
   --base 0x80000000 \
   --kernel_offset 0x8000 \

--- a/build_system.sh
+++ b/build_system.sh
@@ -68,7 +68,6 @@ sudo tar -xf $BUILD_DIR/filesystem.tar > /dev/null
 # Add hostname and hosts. This cannot be done in the docker container...
 echo "Setting network stuff"
 HOST=tici
-sudo bash -c "echo $HOST > etc/hostname"
 sudo bash -c "echo \"127.0.0.1    localhost.localdomain localhost\" > etc/hosts"
 sudo bash -c "echo \"127.0.0.1    $HOST\" >> etc/hosts"
 

--- a/build_system.sh
+++ b/build_system.sh
@@ -68,7 +68,7 @@ sudo tar -xf $BUILD_DIR/filesystem.tar > /dev/null
 # Add hostname and hosts. This cannot be done in the docker container...
 echo "Setting network stuff"
 HOST=tici
-sudo bash -c "ln -s /proc/sys/kernel/hostname etc/hostname"
+sudo bash -c "ln -sf /proc/sys/kernel/hostname etc/hostname"
 sudo bash -c "echo \"127.0.0.1    localhost.localdomain localhost\" > etc/hosts"
 sudo bash -c "echo \"127.0.0.1    $HOST\" >> etc/hosts"
 

--- a/build_system.sh
+++ b/build_system.sh
@@ -68,7 +68,7 @@ sudo tar -xf $BUILD_DIR/filesystem.tar > /dev/null
 # Add hostname and hosts. This cannot be done in the docker container...
 echo "Setting network stuff"
 HOST=tici
-sudo bash -c "rm /etc/hostname && ln -s /proc/sys/kernel/hostname /etc/hostname"
+sudo bash -c "ln -s /proc/sys/kernel/hostname etc/hostname"
 sudo bash -c "echo \"127.0.0.1    localhost.localdomain localhost\" > etc/hosts"
 sudo bash -c "echo \"127.0.0.1    $HOST\" >> etc/hosts"
 

--- a/build_system.sh
+++ b/build_system.sh
@@ -68,6 +68,7 @@ sudo tar -xf $BUILD_DIR/filesystem.tar > /dev/null
 # Add hostname and hosts. This cannot be done in the docker container...
 echo "Setting network stuff"
 HOST=tici
+sudo bash -c "rm /etc/hostname && ln -s /proc/sys/kernel/hostname /etc/hostname"
 sudo bash -c "echo \"127.0.0.1    localhost.localdomain localhost\" > etc/hosts"
 sudo bash -c "echo \"127.0.0.1    $HOST\" >> etc/hosts"
 

--- a/build_system.sh
+++ b/build_system.sh
@@ -67,7 +67,7 @@ sudo tar -xf $BUILD_DIR/filesystem.tar > /dev/null
 
 # Add hostname and hosts. This cannot be done in the docker container...
 echo "Setting network stuff"
-HOST=tici
+HOST=comma
 sudo bash -c "ln -sf /proc/sys/kernel/hostname etc/hostname"
 sudo bash -c "echo \"127.0.0.1    localhost.localdomain localhost\" > etc/hosts"
 sudo bash -c "echo \"127.0.0.1    $HOST\" >> etc/hosts"

--- a/load_kernel.sh
+++ b/load_kernel.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 cd "$(dirname "$0")"
 
-DEVICE=tici-ethernet
+DEVICE=${DEVICE:-tici-ethernet}
 
 scp output/boot.img $DEVICE:/tmp/
 ssh $DEVICE "sudo dd if=/tmp/boot.img of=/dev/disk/by-partlabel/boot_a && sudo dd if=/tmp/boot.img of=/dev/disk/by-partlabel/boot_b && sudo reboot"

--- a/load_kernel.sh
+++ b/load_kernel.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 cd "$(dirname "$0")"
 
-DEVICE=${DEVICE:-tici-ethernet}
+DEVICE=${DEVICE:-comma-ethernet}
 
 scp output/boot.img $DEVICE:/tmp/
 ssh $DEVICE "sudo dd if=/tmp/boot.img of=/dev/disk/by-partlabel/boot_a && sudo dd if=/tmp/boot.img of=/dev/disk/by-partlabel/boot_b && sudo reboot"

--- a/load_kernel_headers.sh
+++ b/load_kernel_headers.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-scp output/linux-headers*.deb tici:/tmp/
-ssh tici "sudo apt install -yq /tmp/linux-headers*.deb"
+scp output/linux-headers*.deb comma:/tmp/
+ssh comma "sudo apt install -yq /tmp/linux-headers*.deb"
 

--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -2,7 +2,7 @@
 
 USERNAME=comma
 PASSWD=comma
-HOST=tici
+HOST=comma
 
 # Create identification file
 touch /TICI

--- a/userspace/files/serial-hostname.service
+++ b/userspace/files/serial-hostname.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Sets the hostname to the device's serial number
-After=NetworkManager.service
+After=basic.target
+Before=network.target
 
 [Service]
 User=root

--- a/userspace/services.sh
+++ b/userspace/services.sh
@@ -8,7 +8,7 @@ systemctl enable cdsprpcd
 
 # Enable our services
 systemctl enable fs_setup.service
-#systemctl enable serial-hostname.service
+systemctl enable serial-hostname.service
 systemctl enable comma.service
 systemctl enable gpio.service
 systemctl enable lte.service
@@ -28,7 +28,6 @@ systemctl enable set_time.service
 systemctl enable phantom_touch_logger.service
 
 # Disable some of our services
-systemctl disable serial-hostname.service
 systemctl disable agnos-tests.service
 
 # Disable third party services

--- a/userspace/usr/comma/set-hostname.sh
+++ b/userspace/usr/comma/set-hostname.sh
@@ -3,4 +3,4 @@ set -e
 
 SERIAL="$(cat /proc/cmdline | sed -e 's/^.*androidboot.serialno=//' -e 's/ .*$//')"
 echo "serial: '$SERIAL'"
-sysctl kernel.hostname="tici-$SERIAL"
+sysctl kernel.hostname="comma-$SERIAL"

--- a/userspace/usr/comma/set-hostname.sh
+++ b/userspace/usr/comma/set-hostname.sh
@@ -3,4 +3,4 @@ set -e
 
 SERIAL="$(cat /proc/cmdline | sed -e 's/^.*androidboot.serialno=//' -e 's/ .*$//')"
 echo "serial: '$SERIAL'"
-hostnamectl set-hostname --transient "tici-$SERIAL"
+sysctl kernel.hostname="tici-$SERIAL"


### PR DESCRIPTION
This even allows using `hostnamectl` to change the hostname (although it changes back to serial number on reboot)
```sh
comma@tici-d62c206c:/data/openpilot$ hostnamectl 
   Static hostname: tici-d62c206c
         Icon name: computer
        Machine ID: 0e56b517e1dbc6ffa9481f7263f690e5
           Boot ID: b86719b5f5904aeeab49a8e89ea8abdf
  Operating System: Ubuntu 20.04.5 LTS
            Kernel: Linux 4.9.103+
      Architecture: arm64

comma@tici-d62c206c:/data/openpilot$ nmcli general hostname
tici-d62c206c
```

Note that the following alternative approaches do not work:
* `hostnamectl set-hostname --transient <new-host-name>` because `NetworkManager` doesn't respect a pre-existing transient hostname.
* `nmcli general hostname <new-host-name>` because it seems impossible to hook it after `NetworkManager` is up and before it brings up network interfaces

(both approaches set the hostname, but not in a way that the hostname reliably gets passed through DHCP for registration in DNS)


TODO:
- [x] test builder change to add symlink
- [x] change from `tici-` to `comma-`
