### PR TITLE
Reduce kernel boot time

### DIFF
--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -45,7 +45,7 @@ cp $DIR/agnos-kernel-sdm845/out/arch/arm64/boot/Image.gz-dtb .
 $TOOLS/mkbootimg \
   --kernel Image.gz-dtb \
   --ramdisk /dev/null \
-  --cmdline "console=ttyMSM0,115200n8 quiet loglevel=3 earlycon=msm_geni_serial,0xA84000 androidboot.hardware=qcom androidboot.console=ttyMSM0 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 service_locator.enable=1 androidboot.selinux=permissive firmware_class.path=/lib/firmware/updates net.ifnames=0 dyndbg=\"\"" \
+  --cmdline "initcall_debug console=ttyMSM0,115200n8 quiet loglevel=3 earlycon=msm_geni_serial,0xA84000 androidboot.hardware=qcom androidboot.console=ttyMSM0 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 service_locator.enable=1 androidboot.selinux=permissive firmware_class.path=/lib/firmware/updates net.ifnames=0 dyndbg=\"\"" \
   --pagesize 4096 \
   --base 0x80000000 \
   --kernel_offset 0x8000 \


### PR DESCRIPTION
Early progress (done on local `agnos-kernel-sdm845`): 
- Disable some debug inits saves about 100 - 200ms. Maybe turning off tracing and debug gonna save a big chunk but not sure how I feel abt turning off debugs though they are not essential for driving and they do take a big chunk during the kernel boot time (maybe 0.5s)
~- preset `lpj`~ (doesn't help)
- deferred_probe_takes more than 0.5s (maybe more optimzation)

```
------  -----  -----  ----
PON     1.5    1.5    10%
XBL     2.4    3.9    16%
ABL     3.7    7.6    25%
kernel  3.48   11.08  23%
weston  6.64   17.72  45%
comma   -2.87  14.85  -19%
onroad  ?      ?      -
------  -----  -----  ----
```

From the `dmesg`, it seems that most of the reduction will be from modifying the kernel functions and modifying the kernel configuration parameters