### PR TITLE
Improve ssh responsiveness on slow Wi-Fi networks

### DIFF
--- a/userspace/files/sshd_config
+++ b/userspace/files/sshd_config
@@ -71,7 +71,7 @@ ClientAliveCountMax 3
 # The low default DSCP of 0x10 lumps ssh traffic in with all other potentially
 # high bandwidth traffic. Raise the priority to ensure that this interactive traffic
 # remains responsive even when we are bandwidth limited.
-IPQoS 0xb8
+IPQoS af42
 
 #MaxStartups 10:30:60
 #Banner /etc/issue.net

--- a/userspace/files/sshd_config
+++ b/userspace/files/sshd_config
@@ -68,7 +68,7 @@ TCPKeepAlive yes
 ClientAliveInterval 10
 ClientAliveCountMax 3
 
-# The low default DSCP of 0x10 lumps ssh traffic in with all other potentially
+# The default DSCP of 0x10 lumps ssh traffic in with all other potentially
 # high bandwidth traffic. Raise the priority to ensure that this interactive traffic
 # remains responsive even when we are bandwidth limited.
 IPQoS af42 # 36, HDD_LINUX_AC_VI with the minimum delay flag

--- a/userspace/files/sshd_config
+++ b/userspace/files/sshd_config
@@ -68,8 +68,8 @@ TCPKeepAlive yes
 ClientAliveInterval 10
 ClientAliveCountMax 3
 
-# The default DSCP of 0x10 lumps ssh traffic in with all other potentially
-# high bandwidth traffic. Raise the priority to ensure that this interactive traffic
+# The default DSCP of 0x10 lumps ssh traffic in with all other potentially high
+# bandwidth traffic. Raise the priority to ensure that this interactive traffic
 # remains responsive even when we are bandwidth limited.
 IPQoS af42 # 36, HDD_LINUX_AC_VI with the minimum delay flag
 

--- a/userspace/files/sshd_config
+++ b/userspace/files/sshd_config
@@ -71,7 +71,7 @@ ClientAliveCountMax 3
 # The low default DSCP of 0x10 lumps ssh traffic in with all other potentially
 # high bandwidth traffic. Raise the priority to ensure that this interactive traffic
 # remains responsive even when we are bandwidth limited.
-IPQoS af42
+IPQoS af42 # 36, HDD_LINUX_AC_VI with the minimum delay flag
 
 #MaxStartups 10:30:60
 #Banner /etc/issue.net

--- a/userspace/files/sshd_config
+++ b/userspace/files/sshd_config
@@ -68,6 +68,11 @@ TCPKeepAlive yes
 ClientAliveInterval 10
 ClientAliveCountMax 3
 
+# The low default DSCP of 0x10 lumps ssh traffic in with all other potentially
+# high bandwidth traffic. Raise the priority to ensure that this interactive traffic
+# remains responsive even when we are bandwidth limited.
+IPQoS 0xb8
+
 #MaxStartups 10:30:60
 #Banner /etc/issue.net
 


### PR DESCRIPTION
# Problem

Our traffic control routing consists of a parent `mq` qdisc that encompasses 5 hardware tx queues with a `pfifo_fast` attached to each. `pfifo_fast` is supposed to prioritize interactive traffic using the ToS/DSCP field, but it is unclear why it does not seem to prevent serious ssh stability issues when the device is uploading a file on a slow network.

I am guessing that we are saturing the one hardware queue we are currently using, making the `pfifo_fast` useless as it can't stuff any more interactive ssh packets into the single hardware queue as it waits for the file packets to send.

Running a speed test, both traffic goes out on one hardware queue (`parent :3`):

```bash
comma@comma-d7e84c3:/data/openpilot$ sudo tc -s qdisc ls dev wlan0
qdisc mq 0: root 
 Sent 158247322 bytes 154641 pkt (dropped 0, overlimits 0 requeues 1) 
 backlog 0b 0p requeues 1
!!!Deficit -4, rta_len=48
qdisc pfifo_fast 0: parent :5 bands 3 priomap 1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1
 Sent 1240 bytes 10 pkt (dropped 0, overlimits 0 requeues 0) 
 backlog 0b 0p requeues 0
!!!Deficit -4, rta_len=48
qdisc pfifo_fast 0: parent :4 bands 3 priomap 1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1
 Sent 0 bytes 0 pkt (dropped 0, overlimits 0 requeues 0) 
 backlog 0b 0p requeues 0
!!!Deficit -4, rta_len=48
qdisc pfifo_fast 0: parent :3 bands 3 priomap 1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1
 Sent 158243956 bytes 154622 pkt (dropped 0, overlimits 0 requeues 1)   # everything is being sent on this hardware queue
 backlog 0b 0p requeues 1
!!!Deficit -4, rta_len=48
qdisc pfifo_fast 0: parent :2 bands 3 priomap 1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1
 Sent 0 bytes 0 pkt (dropped 0, overlimits 0 requeues 0) 
 backlog 0b 0p requeues 0
!!!Deficit -4, rta_len=48
qdisc pfifo_fast 0: parent :1 bands 3 priomap 1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1
 Sent 2126 bytes 9 pkt (dropped 0, overlimits 0 requeues 0) 
 backlog 0b 0p requeues 0
```

---

# Attempted solution

I tried adding a custom `prio` qdisc with 5 bands to replace the default `mq` one, but with just the `priomap` alone, it still kept everything on the same band. This is when I learned that the WiFi driver was resetting every Linux packet priority to 0 before it even got to the `prio` qdisc because it assumes you won't mess with traffic control. It wants to keep all of the queue prioritization inside the driver:

https://github.com/commaai/agnos-kernel-sdm845/blob/737a024adaf5aedf2a50500939a13c6a2e7283d2/drivers/staging/qcacld-3.0/core/hdd/src/wlan_hdd_wmm.c#L1592

BTW the DSCP map is literally just:

```python
dscp_map = {}
for dscp in range(WLAN_HDD_MAX_DSCP + 1):
  dscp_map[dscp] = dscp >> 3
```

Since the ssh default DSCP value is 0x10, that lumps it in with normal high bandwidth traffic of 0x0:

https://github.com/commaai/agnos-kernel-sdm845/blob/737a024adaf5aedf2a50500939a13c6a2e7283d2/drivers/staging/qcacld-3.0/core/hdd/src/wlan_hdd_wmm.c#L1512-L1513

# Solution

Once I moved it to a different hardware queue via raising the ssh QoS field, the ssh connection remains much more responsive on heavily degraded AP conditions while uploading (200-300 Kbps).