### PR TITLE
vim in tmux: fix ctrl+left/right

### DIFF
--- a/userspace/home/.vimrc
+++ b/userspace/home/.vimrc
@@ -12,6 +12,9 @@ highlight Comment ctermfg=green
 highlight ExtraWhitespace ctermbg=red guibg=red
 match ExtraWhitespace /\s\+$/
 
+" fix certain escape sequences
+set term=xterm-256color
+
 " syntax highlighting for scons files
 au BufRead,BufNewFile SConstruct set filetype=python
 au BufRead,BufNewFile SConscript set filetype=python


### PR DESCRIPTION
We can also map the escape sequences tmux gives us, not sure which is better

Currently pressing ctrl+left or right in tmux to skip to the next word deletes multiple lines below the cursor