### PR TITLE
kill: send SIGTERM first

### DIFF
--- a/userspace/files/comma.service
+++ b/userspace/files/comma.service
@@ -6,6 +6,7 @@ User=comma
 Restart=always
 ExecStart=/bin/bash -c "/usr/bin/tmux new-session -s comma -d /usr/comma/comma.sh && sleep infinity"
 TimeoutStopSec=1
+KillSignal=SIGTERM
 RestartKillSignal=SIGKILL
 LimitRTPRIO=100
 LimitNICE=-10

--- a/userspace/files/comma.service
+++ b/userspace/files/comma.service
@@ -6,6 +6,7 @@ User=comma
 Restart=always
 ExecStart=/bin/bash -c "/usr/bin/tmux new-session -s comma -d /usr/comma/comma.sh && sleep infinity"
 TimeoutStopSec=1
+RestartKillSignal=SIGKILL
 LimitRTPRIO=100
 LimitNICE=-10
 

--- a/userspace/files/comma.service
+++ b/userspace/files/comma.service
@@ -5,7 +5,7 @@ Type=simple
 User=comma
 Restart=always
 ExecStart=/bin/bash -c "/usr/bin/tmux new-session -s comma -d /usr/comma/comma.sh && sleep infinity"
-KillSignal=SIGKILL
+TimeoutStopSec=1
 LimitRTPRIO=100
 LimitNICE=-10
 


### PR DESCRIPTION
openpilot processes never have a chance to react to reboot or shutdown since we send SIGKILL first. This adopts the [default behavior](https://www.freedesktop.org/software/systemd/man/latest/systemd.kill.html) of a SIGTERM first, wait a timeout, then a SIGKILL

For https://github.com/commaai/openpilot/pull/32103