### PR TITLE
Fixed incorrectly registering qemu on Apple silicon

### DIFF
--- a/build_system.sh
+++ b/build_system.sh
@@ -10,6 +10,8 @@ export DOCKER_BUILDKIT=1
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 cd $DIR
 
+ARCH=$(uname -m)
+
 BUILD_DIR="$DIR/build"
 OUTPUT_DIR="$DIR/output"
 
@@ -33,11 +35,11 @@ cp $OUTPUT_DIR/snd*.ko $DIR/userspace/usr/comma/sound/
 # Download Ubuntu Base if not done already
 if [ ! -f $UBUNTU_FILE ]; then
   echo -e "${GREEN}Downloading Ubuntu: $UBUNTU_FILE ${NO_COLOR}"
-  wget -c $UBUNTU_BASE_URL/$UBUNTU_FILE --quiet
+  curl -C - -o $UBUNTU_FILE $UBUNTU_BASE_URL/$UBUNTU_FILE --silent
 fi
 
-# Register qemu multiarch
-if [ "$(uname -p)" != "aarch64" ]; then
+if [ "$ARCH" != "arm64" ] && [ "$ARCH" != "aarch64" ]; then
+  # Register qemu multiarch
   docker run --rm --privileged multiarch/qemu-user-static:register --reset
 fi
 


### PR DESCRIPTION
For some reason on an M2 Mac with OrbStack registering qemu messes up the `build_system.sh` script. But on an `arm64` native Ubuntu (Khadas Edge2) works fine even with qemu registered.

Same changes proposed and already exist in https://github.com/commaai/agnos-builder/pull/231