### PR TITLE
Reduce memory usage when building system

### DIFF
--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -82,7 +82,7 @@ RUN export PATH="/usr/local/pyenv/bin:/usr/local/pyenv/shims:$PATH" && \
     export PYENV_ROOT="/usr/local/pyenv" && \
     eval "$(pyenv init -)" && \
     eval "$(pyenv virtualenv-init -)" && \
-    export MAKEFLAGS="-j40" && \
+    export MAKEFLAGS="-j$(nproc)" && \
     pip install pyqt5-sip==12.12.1 && \
     pip install pyqt5==5.15.9 --verbose --config-settings --confirm-license= && \
     pyenv rehash


### PR DESCRIPTION
Switch to `MAKEFLAGS="-j$(nproc)"` for pyqt5 to avoid OOMs