### PR TITLE
switch pyenv to uv

### DIFF
--- a/userspace/openpilot_python_dependencies.sh
+++ b/userspace/openpilot_python_dependencies.sh
@@ -21,4 +21,4 @@ uv venv --python-preference only-system
 # error: No virtual or system environment found for path ...
 source .venv/bin/activate
 # install dependencies using system python 
-uv pip install --python=$(which python) --no-cache-dir --upgrade pip uv
+uv pip install --python=$(which python) --no-cache-dir --upgrade pip

--- a/userspace/openpilot_python_dependencies.sh
+++ b/userspace/openpilot_python_dependencies.sh
@@ -2,19 +2,23 @@
 
 echo "Installing python for openpilot"
 
-if ! command -v "uv" > /dev/null 2>&1; then
-  echo "installing uv..."
-  curl -LsSf https://astral.sh/uv/install.sh | sh
-  UV_BIN='$HOME/.cargo/env'
-  ADD_PATH_CMD=". \"$UV_BIN\""
-  eval $ADD_PATH_CMD
-fi
+echo "installing uv..."
+curl -LsSf https://astral.sh/uv/install.sh | sh
+UV_BIN='$HOME/.cargo/env'
+ADD_PATH_CMD=". \"$UV_BIN\""
+eval $ADD_PATH_CMD
 
 PYTHON_VERSION="3.11.4"
 if [ "$(uname -p)" == "aarch64" ]; then
-  uv python install 3.11.4
+  uv python install $PYTHON_VERSION
 else
   MAKEFLAGS="-j1" MAKE_OPTS="-j1" taskset --cpu-list 0 uv python install --verbose $PYTHON_VERSION
 fi
-uv venv
-uv pip install --no-cache-dir --upgrade pip uv
+
+# uv requires virtual env either managed or system before installing dependencies
+uv venv --python-preference only-system
+# need to activate virtual env otherwise call to uv pip install throws error,
+# error: No virtual or system environment found for path ...
+source .venv/bin/activate
+# install dependencies using system python 
+uv pip install --python=$(which python) --no-cache-dir --upgrade pip uv

--- a/userspace/openpilot_python_dependencies.sh
+++ b/userspace/openpilot_python_dependencies.sh
@@ -2,20 +2,19 @@
 
 echo "Installing python for openpilot"
 
-# Install pyenv
-export PYENV_ROOT="/usr/local/pyenv"
-curl https://pyenv.run | bash
-export PATH="$PYENV_ROOT/bin:$PATH"
-eval "$(pyenv init -)"
+if ! command -v "uv" > /dev/null 2>&1; then
+  echo "installing uv..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  UV_BIN='$HOME/.cargo/env'
+  ADD_PATH_CMD=". \"$UV_BIN\""
+  eval $ADD_PATH_CMD
+fi
 
 PYTHON_VERSION="3.11.4"
 if [ "$(uname -p)" == "aarch64" ]; then
-  pyenv install --verbose $PYTHON_VERSION
+  uv python install 3.11.4
 else
-  MAKEFLAGS="-j1" MAKE_OPTS="-j1" taskset --cpu-list 0 pyenv install --verbose $PYTHON_VERSION
+  MAKEFLAGS="-j1" MAKE_OPTS="-j1" taskset --cpu-list 0 uv python install --verbose $PYTHON_VERSION
 fi
-
-echo "Setting global python version"
-pyenv global $PYTHON_VERSION
-
-pip3 install --no-cache-dir --upgrade pip uv
+uv venv
+uv pip install --no-cache-dir --upgrade pip uv


### PR DESCRIPTION
resolves https://github.com/commaai/agnos-builder/issues/240

openpilot_python_dependencies.sh has been setup to use uv. Dockerfile.agnos still uses pyenv which can also be switched to use uv.