### PR TITLE
Fix python dependencies

### DIFF
--- a/userspace/pyproject.toml
+++ b/userspace/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "libusb1",
   "markdown-it-py",
   "nose",
-  "numpy",
+  "numpy < 2.0.0",
   "onnx",
   "onnxruntime >= 1.16.3",
   "pillow",
@@ -39,7 +39,7 @@ dependencies = [
   "pydub",
   "pyjwt",
   "pylint",
-#"pyopencl == 2024.1", #FIXME: has some installation errors
+  "pyopencl == 2024.1",
   "pyserial",
   "pytest",
   "pytest-cov",

--- a/userspace/pyproject.toml
+++ b/userspace/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "evdev",
   "flake8",
   "flask",
-  "future-fstrings",
+  "future-fstrings",  # needed for acados
   "gunicorn",
   "hatanaka == 2.4",
   "hexdump",
@@ -27,7 +27,7 @@ dependencies = [
   "libusb1",
   "markdown-it-py",
   "nose",
-  "numpy < 2.0.0",
+  "numpy < 2.0.0",  # pending bumping in openpilot
   "onnx",
   "onnxruntime >= 1.16.3",
   "pillow",
@@ -40,7 +40,7 @@ dependencies = [
   "pydub",
   "pyjwt",
   "pylint",
-  "pyopencl == 2024.1",
+  "pyopencl == 2024.1",  # pending cmake update coming with 24.04
   "pyserial",
   "pytest",
   "pytest-cov",

--- a/userspace/pyproject.toml
+++ b/userspace/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "pydub",
   "pyjwt",
   "pylint",
-  "pyopencl == 2024.1",  # pending cmake update coming with 24.04
+  "pyopencl == 2024.1",  # pinned until cmake update coming with 24.04
   "pyserial",
   "pytest",
   "pytest-cov",

--- a/userspace/pyproject.toml
+++ b/userspace/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "evdev",
   "flake8",
   "flask",
+  "future-fstrings",
   "gunicorn",
   "hatanaka == 2.4",
   "hexdump",

--- a/userspace/uv.lock
+++ b/userspace/uv.lock
@@ -27,6 +27,7 @@ dependencies = [
     { name = "evdev" },
     { name = "flake8" },
     { name = "flask" },
+    { name = "future-fstrings" },
     { name = "gunicorn" },
     { name = "hatanaka" },
     { name = "hexdump" },

--- a/userspace/uv.lock
+++ b/userspace/uv.lock
@@ -49,6 +49,7 @@ dependencies = [
     { name = "pydub" },
     { name = "pyjwt" },
     { name = "pylint" },
+    { name = "pyopencl" },
     { name = "pyserial" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -377,12 +378,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/a6/edb201c436c820779b1f4e2bf5a74b6fd5e4d7d7b703336e5c0518e1b08f/casadi-3.6.5-cp27-none-manylinux1_i686.whl", hash = "sha256:b5192dfabf6f5266b168b984d124dd3086c1c5a408c0743ff3a82290a8ccf3b5", size = 47956673 },
     { url = "https://files.pythonhosted.org/packages/f7/4d/6c8f37e08a3a91a69be8fffa67ce4a27823d3d4ca2099312f938690938f9/casadi-3.6.5-cp27-none-manylinux2010_x86_64.whl", hash = "sha256:35b2ff6098e386a4d5e8bc681744e52bcd2f2f15cfa44c09814a8979b51a6794", size = 53936205 },
     { url = "https://files.pythonhosted.org/packages/b5/95/1a087e511ded93ab74f3a0adf36a4beaee22ce30d2951ab7115dad3d26b5/casadi-3.6.5-cp27-none-win_amd64.whl", hash = "sha256:caf395d1e36bfb215b154e8df61583d534a07ddabb18cbe50f259b7692a41ac8", size = 43027309 },
-    { url = "https://files.pythonhosted.org/packages/a6/29/11a974e24bdaa50c0ee4c03b8631c7cfed65b5caba5123d91331d4cb969b/casadi-3.6.5-cp310-none-macosx_10_13_x86_64.macosx_10_13_intel.whl", hash = "sha256:314886ef44bd01f1a98579e7784a3bed6e0584e88f9465cf9596af2523efb0dd", size = 42876397 },
-    { url = "https://files.pythonhosted.org/packages/31/57/28043eca210517b9071ef41e4b965ed3f9366e4441b6af5d172466b76d5e/casadi-3.6.5-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:c6789c8060a99b329bb584d97c1eab6a5e4f3e2d2db391e6c2001c6323774990", size = 40753981 },
-    { url = "https://files.pythonhosted.org/packages/56/21/ef9baac75ada94da8d2470578533cbd3a48755277e9dbcd2d65b954678c2/casadi-3.6.5-cp310-none-manylinux2014_aarch64.whl", hash = "sha256:e40afb3c062817dd6ce2497cd001f00f107ee1ea41ec4d6ee9f9a5056d219e83", size = 42905440 },
-    { url = "https://files.pythonhosted.org/packages/3d/89/0bfc9a71d632750685763751698b233f5a9622cea8fbdb03f94bcfe04950/casadi-3.6.5-cp310-none-manylinux2014_i686.whl", hash = "sha256:ee5a4ed50d2becd0bd6d203c7a60ffad27c14a3e0ae357480de11c846a8dd928", size = 69778574 },
-    { url = "https://files.pythonhosted.org/packages/b4/b0/1289804327602e892c36f14fa2b4492afbeee8f465a365c8759b03186f1c/casadi-3.6.5-cp310-none-manylinux2014_x86_64.whl", hash = "sha256:1ddb6e4afdd1da95d7d9d652ed973c1b7f50ef1454965a9170b657e223a2c73e", size = 72306982 },
-    { url = "https://files.pythonhosted.org/packages/b3/bc/95a28e081c303b876b1fd85edc3acc26f73430c056b5aea273ece5765c66/casadi-3.6.5-cp310-none-win_amd64.whl", hash = "sha256:e96ca81b00b9621007d45db1254fcf232d518ebcc802f42853f57b4df977c567", size = 43057148 },
     { url = "https://files.pythonhosted.org/packages/7b/fa/7198dff19f2d6d511c220f1815709581ff9e533403cfeebe187f204f68b2/casadi-3.6.5-cp311-none-macosx_10_13_x86_64.macosx_10_13_intel.whl", hash = "sha256:bebd3909db24ba711e094aacc0a2329b9903d422d73f61be851873731244b7d1", size = 42876397 },
     { url = "https://files.pythonhosted.org/packages/3d/fc/2ba7f33fa843f56cc4df55b4027a037f7f34e8396bd585003f113ee6bcfa/casadi-3.6.5-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:ccb962ea02b7d6d245d5cd40fb52c29e812040a45273c6eed32cb8fcff673dda", size = 40752910 },
     { url = "https://files.pythonhosted.org/packages/1f/c1/2a3290487330fa334c3a86308f9378dce226a7f0f3f7bd11a8f70ac47d3b/casadi-3.6.5-cp311-none-manylinux2014_aarch64.whl", hash = "sha256:1ce199a4ea1d376edbe5399cd622a4564040c83f50c50114fe50a69a8ea81d92", size = 42905415 },
@@ -394,32 +389,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/46/49/551760cdcedcd8d0fd7109d620c7c9e332cb8a706b2bd1beec6e4fda1cd1/casadi-3.6.5-cp312-none-manylinux2014_i686.whl", hash = "sha256:be40e9897d80fb72a97e750b2143c32f63f8800cfb78f9b396d8ce7a913fca39", size = 69777406 },
     { url = "https://files.pythonhosted.org/packages/ff/17/2f97a9638072216448b50fd14855939abeff1632edac92739683ffac9b08/casadi-3.6.5-cp312-none-manylinux2014_x86_64.whl", hash = "sha256:0118637823e292a9270133e02c9c6d3f3c7f75e8c91a6f6dc5275ade82dd1d9d", size = 72311551 },
     { url = "https://files.pythonhosted.org/packages/88/08/c55e2172f033a44b831ee771bb32fa89c369311c0598a52c03755f29a75e/casadi-3.6.5-cp312-none-win_amd64.whl", hash = "sha256:fe2b64d777e36cc3f101220dd1e219a0e11c3e4ee2b5e708b30fea9a27107e41", size = 43057681 },
-    { url = "https://files.pythonhosted.org/packages/66/e7/2b24199211f92b8ba3533fe09bef42b352caccf381429e7fda449f07458b/casadi-3.6.5-cp35-none-macosx_10_13_x86_64.macosx_10_13_intel.whl", hash = "sha256:a1ae36449adec534125d4af5be912b6fb9dafe74d1fee39f6c82263695e21ca5", size = 42869977 },
-    { url = "https://files.pythonhosted.org/packages/4d/0d/fea3604668c7bda76fa874d057a001d0006074cb6d2dca7af60d0635e1c6/casadi-3.6.5-cp35-none-manylinux1_i686.whl", hash = "sha256:32644c47fbfb643d5cf9769c7bbc94c6bdb9a40ea9c12c54af5e2754599c3186", size = 47970545 },
-    { url = "https://files.pythonhosted.org/packages/a1/5d/16cf69bb8a00059fb0e4c6e21ed5d550a99b17a1dee5e4cae304b4a1456e/casadi-3.6.5-cp35-none-manylinux2010_x86_64.whl", hash = "sha256:601b76b7afcb27b11563999f6ad1d9d2a2510ab3d00a6f4ce86a0bee97c9d17a", size = 53958472 },
-    { url = "https://files.pythonhosted.org/packages/ab/7d/9204a8c2e6a8a3f6447d2d9e5e0b177443dcd9f8b5165743f26a1335a3da/casadi-3.6.5-cp35-none-win_amd64.whl", hash = "sha256:febc645bcc0aed6d7a2bdb6e58b9a89cb8f74b19bc028c41cc807d75a5d54058", size = 43041688 },
-    { url = "https://files.pythonhosted.org/packages/a8/e4/a5ae1ef8909b26dd7c4ab7f5303a3ac298c143661b437d9070c0608d35ae/casadi-3.6.5-cp36-none-macosx_10_13_x86_64.macosx_10_13_intel.whl", hash = "sha256:c98e68023c9e5905d9d6b99ae1fbbfe4b85ba9846b3685408bb498b20509f99a", size = 42869977 },
-    { url = "https://files.pythonhosted.org/packages/22/57/e7d2fad22a74f0ef7a5e4fc2ec77fbf11258743b94a0bbffa73f9cbdc468/casadi-3.6.5-cp36-none-manylinux2014_aarch64.whl", hash = "sha256:eb311088dca5359acc05aa4d8895bf99afaa16c7c04b27bf640ce4c2361b8cde", size = 42899148 },
-    { url = "https://files.pythonhosted.org/packages/d8/b5/c2dd2ff700d03db674cfacfa97678d7b6621cf02b47e9553616de48b3970/casadi-3.6.5-cp36-none-manylinux2014_i686.whl", hash = "sha256:bceb69bf9f04fded8a564eb64e298d19e945eaf4734f7145a5ee61cf9ac693e7", size = 69772344 },
-    { url = "https://files.pythonhosted.org/packages/92/fb/4c6b4682084eb8b567a909bea7d03b4f0bad00bdcf66aea4f29fd1dda66f/casadi-3.6.5-cp36-none-manylinux2014_x86_64.whl", hash = "sha256:c951031e26d987986dbc334492b2e6ef108077f11c00e178ff4007e4a9bf91d8", size = 72306252 },
-    { url = "https://files.pythonhosted.org/packages/8d/33/7c90f3fcb4dae99f9052a494d98c9d0c8c8b22cdca169af847a5ea4e9bb7/casadi-3.6.5-cp36-none-win_amd64.whl", hash = "sha256:e44af450ce944649932f9ef63ff00d2d21f642b506444418b4b20e69dba3adaf", size = 43041687 },
-    { url = "https://files.pythonhosted.org/packages/fd/28/b22c8206615ca24f71c2ea52ff552e74d6eb0afc850750ad8bd97d778a6d/casadi-3.6.5-cp37-none-macosx_10_13_x86_64.macosx_10_13_intel.whl", hash = "sha256:c661fe88a93b7cc7ea42802aac76a674135cd65e3e564a6f08570dd3bea05201", size = 42869949 },
-    { url = "https://files.pythonhosted.org/packages/14/40/d5c1d9b3e964ef295eee7cc518c8e1abd7cb92bbfc6dcd74f9aa30839731/casadi-3.6.5-cp37-none-manylinux2014_aarch64.whl", hash = "sha256:5266fc82e39352e26cb1a4e0a5c3deb32d09e6333be637bd78c273fa50f9012b", size = 42899157 },
-    { url = "https://files.pythonhosted.org/packages/26/b3/85ff05610e862a90f70daa4e58772dc9719dde2a5481ff293ca27e056729/casadi-3.6.5-cp37-none-manylinux2014_i686.whl", hash = "sha256:02d6fb63c460abd99a450e861034d97568a8aec621fc0a4fed22f7494989c682", size = 69773643 },
-    { url = "https://files.pythonhosted.org/packages/6b/e4/12562e3b7411afc15f923fbd9a39d065590e48e5949a395114b4e3825e56/casadi-3.6.5-cp37-none-manylinux2014_x86_64.whl", hash = "sha256:5e8adffe2015cde370fc545b2d0fe731e96e583e4ea4c5f3044e818fea975cfc", size = 72306085 },
-    { url = "https://files.pythonhosted.org/packages/bb/0d/6af19e039d99342200b9418063501c0555a57e27b461a3112812422c854f/casadi-3.6.5-cp37-none-win_amd64.whl", hash = "sha256:7ea8545579872b6f5412985dafec26b906b67bd4639a6c718b7e07f802af4e42", size = 43041620 },
-    { url = "https://files.pythonhosted.org/packages/b6/67/68eebae41a005e3897dd69b83680f18a1548b2132b87e13b595cea83b0f1/casadi-3.6.5-cp38-none-macosx_10_13_x86_64.macosx_10_13_intel.whl", hash = "sha256:0a38bf808bf51368607c64307dd77a7363fbe8e5c910cd5c605546be60edfaff", size = 42876576 },
-    { url = "https://files.pythonhosted.org/packages/d3/1d/faed4b8b127d336e27753d7f9ef6895edcf4697e0f027e9eb4f934fef49d/casadi-3.6.5-cp38-none-macosx_11_0_arm64.whl", hash = "sha256:f62f779481b30e5ea88392bdb8225e9545a21c4460dc3e96c2b782405b938d04", size = 40757892 },
-    { url = "https://files.pythonhosted.org/packages/bf/6b/b47ff3b2dfc61cf0abbb0516f1621488afa199c0d79266d627e1e4c840c3/casadi-3.6.5-cp38-none-manylinux2014_aarch64.whl", hash = "sha256:deb2cb2bee8aba0c2cad03c832965b51ca305d0f8eb15de8b857ba86a76f0db0", size = 42906110 },
-    { url = "https://files.pythonhosted.org/packages/f6/0a/55839ba892dd3371b1ef96722fc11241834012c9fe5bef8396239470e244/casadi-3.6.5-cp38-none-manylinux2014_i686.whl", hash = "sha256:f6e10b66d6ae8216dab01532f7ad75cc9d66a95125d421b33d078a51ea0fc2a0", size = 69780479 },
-    { url = "https://files.pythonhosted.org/packages/70/25/b4aadc6efbab3603b9f344e09e415fd79cded82e3934d7ade6fd25c4df6e/casadi-3.6.5-cp38-none-manylinux2014_x86_64.whl", hash = "sha256:f9e82658c910e3317535d769334260e0a24d97bbce68cadb72f592e9fcbafd61", size = 72307901 },
-    { url = "https://files.pythonhosted.org/packages/07/e2/d859726b623a6239fcb3a95b78bc2aa932d9e162cf5755bd7ec942b02623/casadi-3.6.5-cp38-none-win_amd64.whl", hash = "sha256:092e448e05feaed8958d684e896d909e756d199b84d3b9d0182da38cd3deebf6", size = 43054557 },
-    { url = "https://files.pythonhosted.org/packages/42/32/0924ac73b83258322d2d4ab4aeabcc615b428e6b6e60eb72fc068428d4e0/casadi-3.6.5-cp39-none-macosx_10_13_x86_64.macosx_10_13_intel.whl", hash = "sha256:f9c1de9a798767c00f89c27677b74059df4c9601d69270967b06d7fcff204b4d", size = 42876397 },
-    { url = "https://files.pythonhosted.org/packages/f4/09/8f56da3a01294ccbaeecc47ef6500b43a0abd5920e99fe7cf2ea28649b12/casadi-3.6.5-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:83e3404de4449cb7382e49d811eec79cd370e64b97b5c94b155c604d7c523a40", size = 40753984 },
-    { url = "https://files.pythonhosted.org/packages/ef/7a/8eb40df7b234ffff254714b48a51ad7181496122dbc342e4b7ce714c8103/casadi-3.6.5-cp39-none-manylinux2014_aarch64.whl", hash = "sha256:af95de5aa5942d627d43312834791623384c2ad6ba87928bf0e3cacc8a6698e8", size = 42905431 },
-    { url = "https://files.pythonhosted.org/packages/a1/78/3655586496b7560e9a3a789dc8185ed3e30a48b147069b2e26e8c98c9e23/casadi-3.6.5-cp39-none-manylinux2014_i686.whl", hash = "sha256:dbeb50726603454a1f85323cba7caf72524cd43ca0aeb1f286d07005a967ece9", size = 69778788 },
-    { url = "https://files.pythonhosted.org/packages/a1/f8/06b68c5f7fa724c8ce5b5a7c269c7836efc10914d97dc0d37c497f5937b0/casadi-3.6.5-cp39-none-manylinux2014_x86_64.whl", hash = "sha256:8bbfb2eb8cb6b9e2384814d6427e48bcf6df049bf7ed05b0a58bb311a1fbf18c", size = 72306869 },
-    { url = "https://files.pythonhosted.org/packages/81/16/c413a49a582935009f6fd9e7b031c43a3b2e919c02e38de0dba1b91d776f/casadi-3.6.5-cp39-none-win_amd64.whl", hash = "sha256:0e4a4ec2e26ebeb22b0c129f2db3cf90f730cf9fbe98adb9a12720ff6ca1834a", size = 43056766 },
 ]
 
 [[distribution]]
@@ -570,7 +539,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/e5/829ddcfb29ad41661ba8e9cac7dc52100fd2c4853bb93d668a3ebde64862/coverage-7.5.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:581ea96f92bf71a5ec0974001f900db495488434a6928a2ca7f01eee20c23805", size = 237309 },
     { url = "https://files.pythonhosted.org/packages/98/f6/f9c96fbf9b36be3f4d8c252ab2b4944420d99425f235f492784498804182/coverage-7.5.4-cp312-cp312-win32.whl", hash = "sha256:73ca8fbc5bc622e54627314c1a6f1dfdd8db69788f3443e752c215f29fa87a0b", size = 207988 },
     { url = "https://files.pythonhosted.org/packages/0e/c1/2b7c7dcf4c273aac7676f12fb2b5524b133671d731ab91bd9a41c21675b9/coverage-7.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:cef4649ec906ea7ea5e9e796e68b987f83fa9a718514fe147f538cfeda76d7a7", size = 208756 },
-    { url = "https://files.pythonhosted.org/packages/7a/c3/a5b06a07b68795018f47b5d69b523ad473ac9ee66be3c22c4d3e5eadd91e/coverage-7.5.4-pp38.pp39.pp310-none-any.whl", hash = "sha256:79b356f3dd5b26f3ad23b35c75dbdaf1f9e2450b6bcefc6d0825ea0aa3f86ca5", size = 197342 },
 ]
 
 [[distribution]]
@@ -1436,30 +1404,26 @@ wheels = [
 
 [[distribution]]
 name = "numpy"
-version = "2.0.0"
+version = "1.26.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/35/fb1ada118002df3fe91b5c3b28bc0d90f879b881a5d8f68b1f9b79c44bfe/numpy-2.0.0.tar.gz", hash = "sha256:cf5d1c9e6837f8af9f92b6bd3e86d513cdc11f60fd62185cc49ec7d1aba34864", size = 18326228 }
+sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/52/a1aea658c7134ea0977542fc4d1aa6f1f9876c6a14ffeecd9394d839bc16/numpy-2.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ad0c86f3455fbd0de6c31a3056eb822fc939f81b1618f10ff3406971893b62a5", size = 21218342 },
-    { url = "https://files.pythonhosted.org/packages/77/4d/ba4a60298c55478b34f13c97a0ac2cf8d225320322976252a250ed04040a/numpy-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e7f387600d424f91576af20518334df3d97bc76a300a755f9a8d6e4f5cadd289", size = 13272871 },
-    { url = "https://files.pythonhosted.org/packages/01/4a/611a907421d8098d5edc8c2b10c3583796ee8da4156f8f7de52c2f4c9d90/numpy-2.0.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:34f003cb88b1ba38cb9a9a4a3161c1604973d7f9d5552c38bc2f04f829536609", size = 5237037 },
-    { url = "https://files.pythonhosted.org/packages/4f/c1/42d1789f1dff7b65f2d3237eb88db258a5a7fdfb981b895509887c92838d/numpy-2.0.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:b6f6a8f45d0313db07d6d1d37bd0b112f887e1369758a5419c0370ba915b3871", size = 6886342 },
-    { url = "https://files.pythonhosted.org/packages/cd/37/595f27a95ff976e8086bc4be1ede21ed24ca4bc127588da59197a65d066f/numpy-2.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f64641b42b2429f56ee08b4f427a4d2daf916ec59686061de751a55aafa22e4", size = 13913798 },
-    { url = "https://files.pythonhosted.org/packages/d1/27/2a7bd6855dc717aeec5f553073a3c426b9c816126555f8e616392eab856b/numpy-2.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a7039a136017eaa92c1848152827e1424701532ca8e8967fe480fe1569dae581", size = 19292279 },
-    { url = "https://files.pythonhosted.org/packages/1b/54/966a3f5a93d709672ad851f6db52461c0584bab52f2230cf76be482302c6/numpy-2.0.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:46e161722e0f619749d1cd892167039015b2c2817296104487cd03ed4a955995", size = 19709770 },
-    { url = "https://files.pythonhosted.org/packages/cc/8b/9340ac45b6cd8bb92a03f797dbe9b7949f5b3789482e1d824cbebc80fda7/numpy-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0e50842b2295ba8414c8c1d9d957083d5dfe9e16828b37de883f51fc53c4016f", size = 14417906 },
-    { url = "https://files.pythonhosted.org/packages/fa/46/614507d78ca8ce1567ac2c3bf7a79bfd413d6fc96dc6b415abaeb3734c0a/numpy-2.0.0-cp311-cp311-win32.whl", hash = "sha256:2ce46fd0b8a0c947ae047d222f7136fc4d55538741373107574271bc00e20e8f", size = 6357084 },
-    { url = "https://files.pythonhosted.org/packages/9b/0f/022ca4783b6e6239a53b988a4d315d67f9ae7126227fb2255054a558bd72/numpy-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:fbd6acc766814ea6443628f4e6751d0da6593dae29c08c0b2606164db026970c", size = 16511678 },
-    { url = "https://files.pythonhosted.org/packages/b7/c8/899826a2d5c94f607f5e4a6f1a0e8b07c8fea3a5b674c5706115b8aad9bb/numpy-2.0.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:354f373279768fa5a584bac997de6a6c9bc535c482592d7a813bb0c09be6c76f", size = 20944792 },
-    { url = "https://files.pythonhosted.org/packages/fe/ec/8ae7750d33565769c8bb7ba925d4e73ecb2de6cd8eaa6fd527fbd52797ee/numpy-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4d2f62e55a4cd9c58c1d9a1c9edaedcd857a73cb6fda875bf79093f9d9086f85", size = 13042186 },
-    { url = "https://files.pythonhosted.org/packages/3f/ab/1dc9f176d3084a2546cf76eb213dc61586d015ef59b3b17947b0e40038af/numpy-2.0.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:1e72728e7501a450288fc8e1f9ebc73d90cfd4671ebbd631f3e7857c39bd16f2", size = 4977729 },
-    { url = "https://files.pythonhosted.org/packages/a0/97/61ed64cedc1b94a7939e3ab3db587822320d90a77bef70fcb586ea7c1931/numpy-2.0.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:84554fc53daa8f6abf8e8a66e076aff6ece62de68523d9f665f32d2fc50fd66e", size = 6610230 },
-    { url = "https://files.pythonhosted.org/packages/bb/31/1f050169270d51ef0346d4c84c7df1c45af16ea304ed5f7151584788d32e/numpy-2.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c73aafd1afca80afecb22718f8700b40ac7cab927b8abab3c3e337d70e10e5a2", size = 13619789 },
-    { url = "https://files.pythonhosted.org/packages/28/95/b56fc6b2abe37c03923b50415df483cf93e09e7438872280a5486131d804/numpy-2.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49d9f7d256fbc804391a7f72d4a617302b1afac1112fac19b6c6cec63fe7fe8a", size = 18993635 },
-    { url = "https://files.pythonhosted.org/packages/df/16/4c165a5194fc70e4a131f8db463e6baf34e0d191ed35d40a161ee4c885d4/numpy-2.0.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0ec84b9ba0654f3b962802edc91424331f423dcf5d5f926676e0150789cb3d95", size = 19408219 },
-    { url = "https://files.pythonhosted.org/packages/00/4c/440bad868bd3aff4fe4e293175a20da70cddff8674b3654eb2f112868ccf/numpy-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:feff59f27338135776f6d4e2ec7aeeac5d5f7a08a83e80869121ef8164b74af9", size = 14101574 },
-    { url = "https://files.pythonhosted.org/packages/26/18/49f1e851f4157198c50f67ea3462797283aa36dd4b0c24b15f63e8118481/numpy-2.0.0-cp312-cp312-win32.whl", hash = "sha256:c5a59996dc61835133b56a32ebe4ef3740ea5bc19b3983ac60cc32be5a665d54", size = 6060205 },
-    { url = "https://files.pythonhosted.org/packages/ad/9c/4a93b8e395b755c53628573d75d7b21985d9a0f416e978d637084ccc8ec3/numpy-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:a356364941fb0593bb899a1076b92dfa2029f6f5b8ba88a14fd0984aaf76d0df", size = 16208660 },
+    { url = "https://files.pythonhosted.org/packages/11/57/baae43d14fe163fa0e4c47f307b6b2511ab8d7d30177c491960504252053/numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71", size = 20630554 },
+    { url = "https://files.pythonhosted.org/packages/1a/2e/151484f49fd03944c4a3ad9c418ed193cfd02724e138ac8a9505d056c582/numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef", size = 13997127 },
+    { url = "https://files.pythonhosted.org/packages/79/ae/7e5b85136806f9dadf4878bf73cf223fe5c2636818ba3ab1c585d0403164/numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e", size = 14222994 },
+    { url = "https://files.pythonhosted.org/packages/3a/d0/edc009c27b406c4f9cbc79274d6e46d634d139075492ad055e3d68445925/numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5", size = 18252005 },
+    { url = "https://files.pythonhosted.org/packages/09/bf/2b1aaf8f525f2923ff6cfcf134ae5e750e279ac65ebf386c75a0cf6da06a/numpy-1.26.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a", size = 13885297 },
+    { url = "https://files.pythonhosted.org/packages/df/a0/4e0f14d847cfc2a633a1c8621d00724f3206cfeddeb66d35698c4e2cf3d2/numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a", size = 18093567 },
+    { url = "https://files.pythonhosted.org/packages/d2/b7/a734c733286e10a7f1a8ad1ae8c90f2d33bf604a96548e0a4a3a6739b468/numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20", size = 5968812 },
+    { url = "https://files.pythonhosted.org/packages/3f/6b/5610004206cf7f8e7ad91c5a85a8c71b2f2f8051a0c0c4d5916b76d6cbb2/numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2", size = 15811913 },
+    { url = "https://files.pythonhosted.org/packages/95/12/8f2020a8e8b8383ac0177dc9570aad031a3beb12e38847f7129bacd96228/numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218", size = 20335901 },
+    { url = "https://files.pythonhosted.org/packages/75/5b/ca6c8bd14007e5ca171c7c03102d17b4f4e0ceb53957e8c44343a9546dcc/numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b", size = 13685868 },
+    { url = "https://files.pythonhosted.org/packages/79/f8/97f10e6755e2a7d027ca783f63044d5b1bc1ae7acb12afe6a9b4286eac17/numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b", size = 13925109 },
+    { url = "https://files.pythonhosted.org/packages/0f/50/de23fde84e45f5c4fda2488c759b69990fd4512387a8632860f3ac9cd225/numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed", size = 17950613 },
+    { url = "https://files.pythonhosted.org/packages/4c/0c/9c603826b6465e82591e05ca230dfc13376da512b25ccd0894709b054ed0/numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a", size = 13572172 },
+    { url = "https://files.pythonhosted.org/packages/76/8c/2ba3902e1a0fc1c74962ea9bb33a534bb05984ad7ff9515bf8d07527cadd/numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0", size = 17786643 },
+    { url = "https://files.pythonhosted.org/packages/28/4a/46d9e65106879492374999e76eb85f87b15328e06bd1550668f79f7b18c6/numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110", size = 5677803 },
+    { url = "https://files.pythonhosted.org/packages/16/2e/86f24451c2d530c88daf997cb8d6ac622c1d40d19f5a031ed68a4b73a374/numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818", size = 15517754 },
 ]
 
 [[distribution]]
@@ -2083,6 +2047,29 @@ wheels = [
 ]
 
 [[distribution]]
+name = "pyopencl"
+version = "2024.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "platformdirs" },
+    { name = "pytools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/c5/6c35b54896484c98d0375190fa81448e2a0638fced6680ff8afcc2941065/pyopencl-2024.1.tar.gz", hash = "sha256:ecd572ee940ad8bda1639c3a7beb68834fc9a98ad7eb3f6e01aac4f7d9d4bac1", size = 473860 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/91/50832bd95fa4137c65ef050b6f518247f901f6e43b3f0895ade91ace4bcb/pyopencl-2024.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:aa2cf8f4c05245de8360151107357f765408421d1e4e0b785ec9d3b106d0f13f", size = 646303 },
+    { url = "https://files.pythonhosted.org/packages/9d/06/4bb407632b9d28c9ec1f7371d31735e7bc287e82f0147126606e562ad19f/pyopencl-2024.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ba574103bad5338fa6cf0dfe5f53edf0abb3d4b963fc7c69f347f69419fed419", size = 617313 },
+    { url = "https://files.pythonhosted.org/packages/85/07/ec2b37022869f2e1f9ad17770b2eb123ee097756be4ad6278393dc76a001/pyopencl-2024.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad5c462e8e32b4004fd1507d2c7359873453bed8734198c8d6dfd89a066be721", size = 944383 },
+    { url = "https://files.pythonhosted.org/packages/07/92/34aa3653094898b34f23d5d7e595289f3e3e5292d82c393aa4537c8e6b43/pyopencl-2024.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:69161052f2bcf05fecceec0efed306e5231e96da536affad4203645e836db59f", size = 1463983 },
+    { url = "https://files.pythonhosted.org/packages/d2/c4/8fc562404465965401b177fd9f5056b48442587bbd7baa79134a2f1692d7/pyopencl-2024.1-cp311-cp311-win_amd64.whl", hash = "sha256:c989f4d40e1dbaaa713349a6112fd3f022918c75f1466c62685f30b874ff2ede", size = 562121 },
+    { url = "https://files.pythonhosted.org/packages/53/fa/5e379ad3fa766e0f4cf641d755897cc3b2c3344d16e374c6b72378e06427/pyopencl-2024.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:382b996d9928afe12d45a559b43cc1d6f90a08066b684c6d004d978abd05015e", size = 655849 },
+    { url = "https://files.pythonhosted.org/packages/02/4d/706e985a0b7e1de7fb63e32a57b0b81930ec7434aade2a515ef36f5638f5/pyopencl-2024.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1fc08f0f1e940b59d5768959d38972d2d6d41776acb85036678057502ad21997", size = 619177 },
+    { url = "https://files.pythonhosted.org/packages/08/ee/4728417f4bfeb3fd010d355b6a5963d2729552d64787ade3eeec2de9e181/pyopencl-2024.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2aadbd401862396a3ad5fb21df516c04e952c707c6c42dfb014a79b8726f046", size = 941796 },
+    { url = "https://files.pythonhosted.org/packages/d4/02/d231d6b5a8872eefb8584654ae65b24e9605b619c4f3d042cd0494feb113/pyopencl-2024.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:83ddcd972fc77f1e434a4f024bb3d4a09099105ebae1751cc1c0724fb891f7da", size = 1464064 },
+    { url = "https://files.pythonhosted.org/packages/2f/d3/f527ad4a966967685d1e3bf55081945d5aa669f3eb5523af7a2c1383ae39/pyopencl-2024.1-cp312-cp312-win_amd64.whl", hash = "sha256:e3477c703ee2537e80425b09f2b3306128b0be7b8d5ab3792636b8828e4f2abb", size = 563364 },
+]
+
+[[distribution]]
 name = "pyopenssl"
 version = "24.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2268,6 +2255,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[distribution]]
+name = "pytools"
+version = "2024.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "siphash24" },
+    { name = "typing-extensions", marker = "python_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/0f/56e109c0307f831b5d598ad73976aaaa84b4d0e98da29a642e797eaa940c/pytools-2024.1.10.tar.gz", hash = "sha256:9af6f4b045212c49be32bb31fe19606c478ee4b09631886d05a32459f4ce0a12", size = 81741 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/cf/0a6aaa44b1f9e02b8c0648b5665a82246a93bcc75224c167b4fafa25c093/pytools-2024.1.10-py3-none-any.whl", hash = "sha256:9cabb71038048291400e244e2da441a051d86053339bc484e64e58d8ea263f44", size = 88108 },
 ]
 
 [[distribution]]
@@ -2464,6 +2465,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/d8/10a70e86f6c28ae59f101a9de6d77bf70f147180fbf40c3af0f64080adc3/setuptools-70.3.0.tar.gz", hash = "sha256:f171bab1dfbc86b132997f26a119f6056a57950d058587841a0082e8830f9dc5", size = 2333112 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/15/88e46eb9387e905704b69849618e699dc2f54407d8953cc4ec4b8b46528d/setuptools-70.3.0-py3-none-any.whl", hash = "sha256:fe384da74336c398e0d956d1cae0669bc02eed936cdb1d49b57de1990dc11ffc", size = 931070 },
+]
+
+[[distribution]]
+name = "siphash24"
+version = "1.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/d8/beb5183d1acc5a013d273452eac750b51e40855917a1841dead80fcf3086/siphash24-1.6.tar.gz", hash = "sha256:242d6901a81260f618938635a25ae7f208e744f7ee6c571f1b255c1c4c62917d", size = 19659 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/a5/0ffc51fe2e5f96258f0edfae15944006b09517ad7e98fdcbda05c67c70f6/siphash24-1.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3e1b3963c392a2d63cbe16af9171d789d2f15e69eb8314b21fe1e11bdc08205f", size = 80669 },
+    { url = "https://files.pythonhosted.org/packages/80/ea/41d648cbbf3248a30f545f9e41ad5dedee19fcbad1d2baa7e39ae6f2779e/siphash24-1.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:de23d12c8a015904081e347900433a0c4b5e07690dbd0a104ad88929f3b91948", size = 75379 },
+    { url = "https://files.pythonhosted.org/packages/48/a7/d6dcc551c8d53e436c58b7ecc96d1de0c0379c21b1e71b2543d38c039c95/siphash24-1.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8be513de01677e57989e028185a16e531942f7a9578d441481abe8b1085c45d6", size = 100466 },
+    { url = "https://files.pythonhosted.org/packages/eb/46/b906d7e05e3d84239d6a04e3d5f106d96ab26483951c7cf2c5769ea8c894/siphash24-1.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef89477ce8f2e67fca025ad9b1c85b7498c6959baa7d9a502cbb5d8c7085f5b7", size = 105913 },
+    { url = "https://files.pythonhosted.org/packages/4c/98/20159e2be9a957da2dffb3e18648c51ea7a0f09c49b8dce1cb268ca55ca7/siphash24-1.6-cp311-cp311-win32.whl", hash = "sha256:f702e646dc60b7d7915fa37f9357a03a2ec41ffb360b6946baf4801eb9f7e98f", size = 67528 },
+    { url = "https://files.pythonhosted.org/packages/0d/0a/d8da621e624f3dbcf9a7a8066c54ddd2f6af437fc23169431caf6f9b403b/siphash24-1.6-cp311-cp311-win_amd64.whl", hash = "sha256:38715f61f0873e4a8b05125e14f349f465c64a1aaf79b6af0ff6f5f420d55dc5", size = 79961 },
+    { url = "https://files.pythonhosted.org/packages/12/e4/ed944e92883b45996cf2c94447dd47b899c87674340b081b9e8cb317a88f/siphash24-1.6-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:51eefacbe82f8f48bc603eb97f54bf3819324349b69a9cd131ba02c40b1e6c61", size = 82399 },
+    { url = "https://files.pythonhosted.org/packages/f9/d1/6ddbd7ba8972789f60282b9b9b1f88f08d26ef0913906e8ad5a9806c8432/siphash24-1.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c63321003aa1856b1bfd48e6ffbd4bff98afeaacb0fc902cb2ae44b861476335", size = 76253 },
+    { url = "https://files.pythonhosted.org/packages/0d/87/0f125c1e069d09c4a39ab09d76fa9d4fe698bde68197627faeb38603f643/siphash24-1.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f0ff4d068e9b0b3f138ef8e8b6f5de1990539d9d590e75a9a8beb6887535184a", size = 98184 },
+    { url = "https://files.pythonhosted.org/packages/86/57/a274de0a91016cd4f870334a2af1193ffcdb88e34345ca098afea6dd10cb/siphash24-1.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c1a671d91095e1872ca9988695200064ccca8db60133638d6061755fe669552", size = 103311 },
+    { url = "https://files.pythonhosted.org/packages/5d/d4/b6a0c9f119b22938e36d74e0859167ae76c0ea0f7d7786eb48120b0e129d/siphash24-1.6-cp312-cp312-win32.whl", hash = "sha256:2dab672fcda08149b8c15f82ee74d732386428f53239cdb002ac2ad0a1f2f2bc", size = 68366 },
+    { url = "https://files.pythonhosted.org/packages/ef/de/6ebd0f96184f8479e8348dcba93a9f14ff54ac3c6a68866cc77c334d7bdf/siphash24-1.6-cp312-cp312-win_amd64.whl", hash = "sha256:226af78af3b992c953cc4808f2c6a4bba320e91e6c89b34aa2492064fa417ae8", size = 81096 },
 ]
 
 [[distribution]]
@@ -2719,7 +2740,6 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/52/7ab0a00b54aa1651e79a9ebc721d45fba86d8c8ab65c4ec6e0a49f09527a/torch-2.3.1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:7c09a94362778428484bcf995f6004b04952106aee0ef45ff0b4bab484f5498d", size = 61002907 },
     { url = "https://files.pythonhosted.org/packages/07/9a/4c5e74264439837814656201da13a898056a5201c976ef042544bceb840f/torch-2.3.1-cp311-cp311-manylinux1_x86_64.whl", hash = "sha256:b2ec81b61bb094ea4a9dee1cd3f7b76a44555375719ad29f05c0ca8ef596ad39", size = 779156414 },
     { url = "https://files.pythonhosted.org/packages/5c/dc/82b5314ffcffa071440108fdccf59159abcd937b8e4d53f3237914089e60/torch-2.3.1-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:490cc3d917d1fe0bd027057dfe9941dc1d6d8e3cae76140f5dd9a7e5bc7130ab", size = 86949326 },
     { url = "https://files.pythonhosted.org/packages/d3/1d/a257913c89572de61316461db91867f87519146e58132cdeace3d9ffbe1f/torch-2.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:5802530783bd465fe66c2df99123c9a54be06da118fbd785a25ab0a88123758a", size = 159781829 },
@@ -2728,8 +2748,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/a1/e8b286b85f19dd701a4b853c0554898b1fa69cea552c7d1ec39bc86f59aa/torch-2.3.1-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:224259821fe3e4c6f7edf1528e4fe4ac779c77addaa74215eb0b63a5c474d66c", size = 86853451 },
     { url = "https://files.pythonhosted.org/packages/af/77/cf6ceb000f8a064c7b373fb3471d85bcc39917d175af82fead4a2857c669/torch-2.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:e5fdccbf6f1334b2203a61a0e03821d5845f1421defe311dabeae2fc8fbeac2d", size = 159727172 },
     { url = "https://files.pythonhosted.org/packages/49/b6/1a2e3d43d4bc4ad7a4575b3745d707a68d5ed00ba263b205b6281bdd0921/torch-2.3.1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:3c333dc2ebc189561514eda06e81df22bf8fb64e2384746b2cb9f04f96d1d4c8", size = 60978559 },
-    { url = "https://files.pythonhosted.org/packages/81/86/f7cbd092dd2924f242bb585da92c33a00ba40c796944d57a761881b50001/torch-2.3.1-cp38-none-macosx_11_0_arm64.whl", hash = "sha256:bee0bd33dc58aa8fc8a7527876e9b9a0e812ad08122054a5bff2ce5abf005b10", size = 61001529 },
-    { url = "https://files.pythonhosted.org/packages/3e/17/d605f9b95078fb9a4a5d931480b5d35755dc8018349bf70c859f0be47c6d/torch-2.3.1-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:2bb5af780c55be68fe100feb0528d2edebace1d55cb2e351de735809ba7391eb", size = 61003330 },
 ]
 
 [[distribution]]


### PR DESCRIPTION
openpilot doesnt compile with the latest agnos master. The following changes make it work again.
- Re-enable pyopencl
- Downgrade numpy
- Add future-fstrings