### PR TITLE
CI: add system build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,15 +27,6 @@ jobs:
       id: kernel-submodule
       run: echo "ref=$(git ls-tree HEAD | awk '$4 == "agnos-kernel-sdm845"' | awk '{print $3}')" >> "$GITHUB_OUTPUT"
 
-    - name: Restore cache output boot.img and *.ko
-      id: cache-output
-      uses: actions/cache/restore@v4
-      with:
-        key: output-${{ steps.kernel-submodule.outputs.ref }}
-        path: |
-          output/boot.img
-          output/*.ko
-
     - name: Checkout agnos-kernel-sdm845
       uses: actions/checkout@v4
       with:
@@ -52,27 +43,22 @@ jobs:
         default: '2.7.18'
 
     - name: Restore cache kernel build
+      id: cache-kernel-out
       uses: actions/cache/restore@v4
       with:
-        key: kernel-out
+        key: kernel-out-${{ steps.kernel-submodule.outputs.ref }}
         path: agnos-kernel-sdm845/out
+        restore-keys: kernel-out-
 
     - name: Build kernel
       run: ./build_kernel.sh
 
     - name: Save cache kernel build
       uses: actions/cache/save@v4
+      if: always()
       with:
-        key: kernel-out
+        key: ${{ steps.cache-kernel-out.outputs.cache-primary-key }}
         path: agnos-kernel-sdm845/out
-
-    - name: Save cache output boot.img and *.ko
-      uses: actions/cache/save@v4
-      with:
-        key: output-${{ steps.kernel-submodule.outputs.ref }}
-        path: |
-          output/boot.img
-          output/*.ko
 
     - name: Upload artifact boot.img
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,9 +23,20 @@ jobs:
       with:
         lfs: true
 
-    - name: get kernel submodule ref
+    - name: Get commit message
+      if: github.event_name == 'pull_request'
+      run: |
+        if [ "${{ github.event_name }}" == "push" ]; then
+          echo "LAST_COMMIT_MESSAGE='${{ github.event.head_commit.message }}'" | tee -a $GITHUB_ENV
+        elif [ "${{ github.event_name }}" == "workflow_run" ]; then
+          echo "LAST_COMMIT_MESSAGE='${{ github.event.workflow_run.head_commit.message }}'" | tee -a $GITHUB_ENV
+        elif [ "${{ github.event_name }}" == "pull_request" ]; then
+          echo "LAST_COMMIT_MESSAGE=$(curl -s '${{ github.event.pull_request.commits_url }}' | jq -r '.[-1].commit.message')" | tee -a $GITHUB_ENV
+        fi
+
+    - name: Get kernel submodule ref
       id: kernel-submodule
-      run: echo "ref=$(git ls-tree HEAD | awk '$4 == "agnos-kernel-sdm845"' | awk '{print $3}')" >> "$GITHUB_OUTPUT"
+      run: echo "ref=$(git ls-tree HEAD | awk '$4 == "agnos-kernel-sdm845"' | awk '{print $3}')" | tee -a $GITHUB_OUTPUT
 
     - name: Checkout agnos-kernel-sdm845
       uses: actions/checkout@v4
@@ -33,6 +44,11 @@ jobs:
         repository: commaai/agnos-kernel-sdm845
         ref: ${{ steps.kernel-submodule.outputs.ref }}
         path: agnos-kernel-sdm845
+
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        create-symlink: true
 
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install -y bc img2simg
@@ -42,32 +58,19 @@ jobs:
       with:
         default: '2.7.18'
 
-    - name: Restore cache kernel build
-      id: cache-kernel-out
-      uses: actions/cache/restore@v4
-      with:
-        key: kernel-out-${{ steps.kernel-submodule.outputs.ref }}
-        path: agnos-kernel-sdm845/out
-        restore-keys: kernel-out-
-
     - name: Build kernel
       run: ./build_kernel.sh
 
-    - name: Save cache kernel build
-      uses: actions/cache/save@v4
-      if: always()
-      with:
-        key: ${{ steps.cache-kernel-out.outputs.cache-primary-key }}
-        path: agnos-kernel-sdm845/out
-
     - name: Upload artifact boot.img
       uses: actions/upload-artifact@v4
+      if: "contains(env.LAST_COMMIT_MESSAGE, '[upload]')"
       with:
         name: boot.img
         path: output/boot.img
 
     - name: Upload artifact kernel modules
       uses: actions/upload-artifact@v4
+      if: "contains(env.LAST_COMMIT_MESSAGE, '[upload]')"
       with:
         name: kernel-modules
         path: output/*.ko
@@ -77,6 +80,7 @@ jobs:
 
     - name: Upload artifact system.img
       uses: actions/upload-artifact@v4
+      if: "contains(env.LAST_COMMIT_MESSAGE, '[upload]')"
       with:
         name: system.img
         path: output/system.img

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,6 +49,8 @@ jobs:
       uses: hendrikmuhs/ccache-action@v1.2
       with:
         create-symlink: true
+        key: kernel-ccache-${{ steps.kernel-submodule.outputs.ref }}
+        restore-keys: kernel-ccache-
 
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install -y bc img2simg

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,6 @@ jobs:
         lfs: true
 
     - name: Get commit message
-      if: github.event_name == 'pull_request'
       run: |
         if [ "${{ github.event_name }}" == "push" ]; then
           echo "LAST_COMMIT_MESSAGE='${{ github.event.head_commit.message }}'" | tee -a $GITHUB_ENV

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,14 +25,18 @@ jobs:
 
     - name: Get commit message
       run: |
-        if [ "${{ github.event_name }}" == "push" ]; then
-          echo "LAST_COMMIT_MESSAGE='${{ github.event.head_commit.message }}'" | tee -a $GITHUB_ENV
-        elif [ "${{ github.event_name }}" == "workflow_run" ]; then
-          echo "LAST_COMMIT_MESSAGE='${{ github.event.workflow_run.head_commit.message }}'" | tee -a $GITHUB_ENV
-        elif [ "${{ github.event_name }}" == "pull_request" ]; then
-          echo "LAST_COMMIT_MESSAGE=$(curl -s '${{ github.event.pull_request.commits_url }}' | jq -r '.[-1].commit.message')" | tee -a $GITHUB_ENV
-        fi
-
+        {
+          echo 'LAST_COMMIT_MESSAGE<<EOF'
+          if [ "${{ github.event_name }}" == "push" ]; then
+            echo "${{ github.event.head_commit.message }}"
+          elif [ "${{ github.event_name }}" == "workflow_run" ]; then
+            echo "${{ github.event.workflow_run.head_commit.message }}"
+          elif [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "$(curl -s '${{ github.event.pull_request.commits_url }}' | jq -r '.[-1].commit.message')"
+          fi
+          echo EOF
+        } | tee -a $GITHUB_ENV
+    
     - name: Get kernel submodule ref
       id: kernel-submodule
       run: echo "ref=$(git ls-tree HEAD | awk '$4 == "agnos-kernel-sdm845"' | awk '{print $3}')" | tee -a $GITHUB_OUTPUT

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
   build:
     name: build kernel and system
     runs-on: namespace-profile-arm64-8x16-2004-caching
-    timeout-minutes: 40
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
         path: agnos-kernel-sdm845
 
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@c92f40bee50034e84c763e33b317c77adaa81c92
       with:
         create-symlink: true
         key: kernel-ccache-${{ steps.kernel-submodule.outputs.ref }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   build:
-    name: build kernel #and system
+    name: build kernel and system
     runs-on: namespace-profile-arm64-8x16-2004-caching
     timeout-minutes: 20
     steps:
@@ -27,7 +27,17 @@ jobs:
       id: kernel-submodule
       run: echo "ref=$(git ls-tree HEAD | awk '$4 == "agnos-kernel-sdm845"' | awk '{print $3}')" >> "$GITHUB_OUTPUT"
 
+    - name: Restore cache output boot.img and *.ko
+      id: cache-output
+      uses: actions/cache/restore@v4
+      with:
+        key: output-${{ steps.kernel-submodule.outputs.ref }}
+        path: |
+          output/boot.img
+          output/*.ko
+
     - name: Checkout agnos-kernel-sdm845
+      if: steps.cache-output.outputs.cache-hit != 'true'
       uses: actions/checkout@v4
       with:
         repository: commaai/agnos-kernel-sdm845
@@ -42,29 +52,52 @@ jobs:
       with:
         default: '2.7.18'
 
-    - name: Cache kernel build
-      uses: actions/cache@v4
-      id: cache-kernel
+    - name: Restore cache kernel build
+      if: steps.cache-output.outputs.cache-hit != 'true'
+      uses: actions/cache/restore@v4
       with:
-        key: kernel-${{ steps.kernel-submodule.outputs.ref }}
-        path: |
-          agnos-kernel-sdm845/out
-        restore-keys: kernel-
+        key: kernel-out
+        path: agnos-kernel-sdm845/out
 
     - name: Build kernel
+      if: steps.cache-output.outputs.cache-hit != 'true'
       run: ./build_kernel.sh
 
-    - uses: actions/upload-artifact@v4
+    - name: Save cache kernel build
+      uses: actions/cache/save@v4
+      if: steps.cache-output.outputs.cache-hit != 'true'
+      with:
+        key: kernel-out
+        path: agnos-kernel-sdm845/out
+
+    - name: Save cache output boot.img and *.ko
+      uses: actions/cache/save@v4
+      if: steps.cache-output.outputs.cache-hit != 'true'
+      with:
+        key: output-${{ steps.kernel-submodule.outputs.ref }}
+        path: |
+          output/boot.img
+          output/*.ko
+
+    - name: Upload artifact boot.img
+      uses: actions/upload-artifact@v4
+      if: steps.cache-output.outputs.cache-hit != 'true'
       with:
         name: boot.img
         path: output/boot.img
-    - uses: actions/upload-artifact@v4
+
+    - name: Upload artifact kernel modules
+      uses: actions/upload-artifact@v4
+      if: steps.cache-output.outputs.cache-hit != 'true'
       with:
         name: kernel-modules
         path: output/*.ko
 
-    #- run: ./build_system.sh
-    #- uses: actions/upload-artifact@v4
-    #  with:
-    #    name: system.img
-    #    path: output/system.img
+    - name: Build system
+      run: ./build_system.sh
+
+    - name: Upload artifact system.img
+      uses: actions/upload-artifact@v4
+      with:
+        name: system.img
+        path: output/system.img

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
   build:
     name: build kernel and system
     runs-on: namespace-profile-arm64-8x16-2004-caching
-    timeout-minutes: 20
+    timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
       with:
@@ -37,7 +37,6 @@ jobs:
           output/*.ko
 
     - name: Checkout agnos-kernel-sdm845
-      if: steps.cache-output.outputs.cache-hit != 'true'
       uses: actions/checkout@v4
       with:
         repository: commaai/agnos-kernel-sdm845
@@ -53,26 +52,22 @@ jobs:
         default: '2.7.18'
 
     - name: Restore cache kernel build
-      if: steps.cache-output.outputs.cache-hit != 'true'
       uses: actions/cache/restore@v4
       with:
         key: kernel-out
         path: agnos-kernel-sdm845/out
 
     - name: Build kernel
-      if: steps.cache-output.outputs.cache-hit != 'true'
       run: ./build_kernel.sh
 
     - name: Save cache kernel build
       uses: actions/cache/save@v4
-      if: steps.cache-output.outputs.cache-hit != 'true'
       with:
         key: kernel-out
         path: agnos-kernel-sdm845/out
 
     - name: Save cache output boot.img and *.ko
       uses: actions/cache/save@v4
-      if: steps.cache-output.outputs.cache-hit != 'true'
       with:
         key: output-${{ steps.kernel-submodule.outputs.ref }}
         path: |
@@ -81,14 +76,12 @@ jobs:
 
     - name: Upload artifact boot.img
       uses: actions/upload-artifact@v4
-      if: steps.cache-output.outputs.cache-hit != 'true'
       with:
         name: boot.img
         path: output/boot.img
 
     - name: Upload artifact kernel modules
       uses: actions/upload-artifact@v4
-      if: steps.cache-output.outputs.cache-hit != 'true'
       with:
         name: kernel-modules
         path: output/*.ko

--- a/build_system.sh
+++ b/build_system.sh
@@ -33,7 +33,7 @@ fi
 # Copy kernel modules over only if updated - otherwise prevents proper caching later
 if ! cmp -s $OUTPUT_DIR/wlan.ko $DIR/userspace/usr/comma/wlan.ko; then
   echo "Copying wlan.ko"
-cp $OUTPUT_DIR/wlan.ko $DIR/userspace/usr/comma
+  cp $OUTPUT_DIR/wlan.ko $DIR/userspace/usr/comma
 fi
 for ko_file in $OUTPUT_DIR/snd*.ko; do
   target_file="$DIR/userspace/usr/comma/sound/$(basename $ko_file)"

--- a/build_system.sh
+++ b/build_system.sh
@@ -24,24 +24,13 @@ SKIP_CHUNKS_IMAGE="$OUTPUT_DIR/system-skip-chunks.img"
 # Create temp dir if non-existent
 mkdir -p $BUILD_DIR $OUTPUT_DIR
 
-# Check if kernel modules are built
+# Copy kernel modules
 if ! ls $OUTPUT_DIR/*.ko >/dev/null 2>&1; then
   echo "Kernel modules missing. Run ./build_kernel.sh first"
   exit 1
 fi
-
-# Copy kernel modules over only if updated - otherwise prevents proper caching later
-if ! cmp -s $OUTPUT_DIR/wlan.ko $DIR/userspace/usr/comma/wlan.ko; then
-  echo "Copying wlan.ko"
-  cp $OUTPUT_DIR/wlan.ko $DIR/userspace/usr/comma
-fi
-for ko_file in $OUTPUT_DIR/snd*.ko; do
-  target_file="$DIR/userspace/usr/comma/sound/$(basename $ko_file)"
-  if ! cmp -s $ko_file $target_file; then
-    echo "Copying $(basename $ko_file)"
-    cp $ko_file $target_file
-  fi
-done
+cp $OUTPUT_DIR/wlan.ko $DIR/userspace/usr/comma
+cp $OUTPUT_DIR/snd*.ko $DIR/userspace/usr/comma/sound/
 
 # Download Ubuntu Base if not done already
 if [ ! -f $UBUNTU_FILE ]; then


### PR DESCRIPTION
For https://github.com/commaai/agnos-builder/issues/230:

- [x] increase timeout to 40min
- [x] upload artifacts only if [upload] tag is present in commit message
- [x] ccache action to reduce kernel build time
- [x] build_system.sh with docker layers cached in namespace
- [x] ubuntu-base image downloaded with `--remote-time` to persist docker layers

|Step|No cache|Cache|
| :---:        |    :----:   |          :---: |
|kernel|7min|3min*|
|system|33min|2min**|
|upload system image|4min|4min|

\* takes 3min with ccache - on my computer is much faster - caching the `out` folder doesn't make any difference - I assume this is because the absolute path where the kernel is built always changes between runs
\** depends a lot on what docker layers the changes have been made - if the change is on the first layers, it takes longer - if it's on the last layers, it takes less