### PR TITLE
Fix image creation docker workflow in host ubuntu

### DIFF
--- a/Dockerfile.sparsify
+++ b/Dockerfile.sparsify
@@ -1,9 +1,18 @@
 FROM ubuntu:24.04
 
+ARG UNAME
+ARG UID
+ARG GID
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y android-sdk-libsparse-utils && \
     rm -rf /var/lib/apt/lists/*
+
+RUN userdel -r `getent passwd ${UID} | cut -d : -f 1` > /dev/null 2>&1; \
+    groupdel -f `getent group ${GID} | cut -d : -f 1` > /dev/null 2>&1; \
+    groupadd -g ${GID} -o ${UNAME} && \
+    useradd -u $UID -g $GID ${UNAME}
 
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/Dockerfile.sparsify
+++ b/Dockerfile.sparsify
@@ -10,9 +10,11 @@ RUN apt-get update && \
     apt-get install -y android-sdk-libsparse-utils && \
     rm -rf /var/lib/apt/lists/*
 
-RUN userdel -r `getent passwd ${UID} | cut -d : -f 1` > /dev/null 2>&1; \
-    groupdel -f `getent group ${GID} | cut -d : -f 1` > /dev/null 2>&1; \
-    groupadd -g ${GID} -o ${UNAME} && \
-    useradd -u $UID -g $GID ${UNAME}
+RUN if [ ${UID:-0} -ne 0 ] && [ ${GID:-0} -ne 0 ]; then \
+      userdel -r `getent passwd ${UID} | cut -d : -f 1` > /dev/null 2>&1; \
+      groupdel -f `getent group ${GID} | cut -d : -f 1` > /dev/null 2>&1; \
+      groupadd -g ${GID} -o ${UNAME} && \
+      useradd -u $UID -g $GID ${UNAME}; \
+    fi
 
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/build_system.sh
+++ b/build_system.sh
@@ -50,7 +50,11 @@ CONTAINER_ID=$(docker container create --entrypoint /bin/bash agnos-builder:late
 
 # Setup mount container for macOS and CI support (namespace.so)
 echo "Building agnos-mount docker image"
-docker build -f Dockerfile.sparsify -t agnos-mount $DIR
+docker build -f Dockerfile.sparsify -t agnos-mount $DIR \
+  --build-arg UNAME=$(id -nu) \
+  --build-arg UID=$(id -u) \
+  --build-arg GID=$(id -g)
+
 echo "Starting agnos-mount container"
 MOUNT_CONTAINER_ID=$(docker run -d --privileged -v $DIR:$DIR agnos-mount)
 
@@ -66,10 +70,6 @@ exec_as_user() {
 exec_as_root() {
   docker exec $MOUNT_CONTAINER_ID "$@"
 }
-
-# Create host user in container (fixes namespace.so error)
-USERNAME=$(whoami)
-exec_as_root useradd --uid $(id -u) -U -m $USERNAME &> /dev/null
 
 # Create filesystem ext4 image
 echo "Creating empty filesystem"

--- a/build_system.sh
+++ b/build_system.sh
@@ -64,7 +64,7 @@ docker container rm -f $CONTAINER_ID $MOUNT_CONTAINER_ID" EXIT
 
 # Define functions for docker execution
 exec_as_user() {
-  docker exec -u $USERNAME $MOUNT_CONTAINER_ID "$@"
+  docker exec -u $(id -nu) $MOUNT_CONTAINER_ID "$@"
 }
 
 exec_as_root() {


### PR DESCRIPTION
useradd will fail if the host user has uid:gid 1000:1000. 
Fix: Delete user in container if the uid:gid is the same and only then create a new user with the same user name as the host user.