### PR TITLE
uv pip install in a separate tmp folder

### DIFF
--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -88,12 +88,13 @@ RUN export PATH="/usr/local/pyenv/bin:/usr/local/pyenv/shims:$PATH" && \
     pyenv rehash
 
 # Install openpilot python packages
-COPY ./userspace/pyproject.toml ./userspace/uv.lock /tmp/agnos/
+RUN mkdir -p /tmp/agnos/uv
+COPY ./userspace/pyproject.toml ./userspace/uv.lock /tmp/agnos/uv
 RUN export PATH="/usr/local/pyenv/bin:/usr/local/pyenv/shims:$PATH" && \
     export PYENV_ROOT="/usr/local/pyenv" && \
     eval "$(pyenv init -)" && \
     eval "$(pyenv virtualenv-init -)" && \
-    cd /tmp/agnos && \
+    cd /tmp/agnos/uv && \
     export PYOPENCL_CL_PRETEND_VERSION="2.0" && \
     MAKEFLAGS="-j$(nproc)" UV_NO_CACHE=1 uv pip install --no-cache-dir --system .
 


### PR DESCRIPTION
For some reason (might be a `uv` bug), `uv pip install --no-cache-dir --system .` that is ran in `/tmp` also moves all other files from `tmp` to `site-packages` https://github.com/commaai/agnos-builder/issues/225#issuecomment-2248783245.

With this PR I'm running it from an empty folder just with `pyproject.toml` and `uv.lock` inside.

- system.img is back to 4.26 GB from 4.67 GB
- system.img artifact 1.21 GB from 1.59 GB

AGNOS boots fine and `site-packages` is clean again:

<img width="527" alt="image" src="https://github.com/user-attachments/assets/67b63ac1-7c67-4df1-8f8c-f117e36f1c2f">
