### PR TITLE
CI: update get commit message

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,14 +29,16 @@ jobs:
           echo 'LAST_COMMIT_MESSAGE<<EOF'
           if [ "${{ github.event_name }}" == "push" ]; then
             echo "${{ github.event.head_commit.message }}"
-          elif [ "${{ github.event_name }}" == "workflow_run" ]; then
-            echo "${{ github.event.workflow_run.head_commit.message }}"
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            COMMIT_URL=$(echo "${{ github.event.repository.commits_url }}" | sed "s|{/sha}|/${{ github.sha }}|")
+            echo "$(curl -s "$COMMIT_URL" | jq -r '.commit.message')"
           elif [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "$(curl -s '${{ github.event.pull_request.commits_url }}' | jq -r '.[-1].commit.message')"
+            PR_COMMIT_URL=$(echo "${{ github.event.repository.commits_url }}" | sed "s|{/sha}|/${{ github.event.pull_request.head.sha }}|")
+            echo "$(curl -s "$PR_COMMIT_URL" | jq -r '.commit.message')"
           fi
           echo EOF
         } | tee -a $GITHUB_ENV
-    
+
     - name: Get kernel submodule ref
       id: kernel-submodule
       run: echo "ref=$(git ls-tree HEAD | awk '$4 == "agnos-kernel-sdm845"' | awk '{print $3}')" | tee -a $GITHUB_OUTPUT


### PR DESCRIPTION
This is a more battle tested version I tested in a separate [repo](https://github.com/andiradulescu/debug-github-actions-commit-message).

- [x] works with `workflow_dispatch`
- [x] works with `pull_requests` with more than 30 commits (gets the last commit pushed in the PR)

The scope of `Get commit message` is for the `[upload]` tag in commit messages.