### PR TITLE
update flash scripts to always flash active slot

### DIFF
--- a/flash_kernel.sh
+++ b/flash_kernel.sh
@@ -16,4 +16,4 @@ echo "Active slot: $ACTIVE_SLOT"
 echo "Flashing boot_$ACTIVE_SLOT..."
 tools/edl w boot_$ACTIVE_SLOT $DIR/output/boot.img
 
-echo "Done!"
+echo "Flashed boot_$ACTIVE_SLOT!"

--- a/flash_kernel.sh
+++ b/flash_kernel.sh
@@ -4,7 +4,16 @@ set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 cd $DIR
 
-echo "Flashing kernel..."
-tools/edl w boot_a $DIR/output/boot.img
+echo "Checking active slot..."
+ACTIVE_SLOT=$(tools/edl getactiveslot | grep "Current active slot:" | awk '{print $NF}')
+
+if [[ "$ACTIVE_SLOT" != "a" && "$ACTIVE_SLOT" != "b" ]]; then
+  echo "Invalid active slot: '$ACTIVE_SLOT'"
+  exit 1
+fi
+
+echo "Active slot: $ACTIVE_SLOT"
+echo "Flashing boot_$ACTIVE_SLOT..."
+tools/edl w boot_$ACTIVE_SLOT $DIR/output/boot.img
 
 echo "Done!"

--- a/flash_kernel.sh
+++ b/flash_kernel.sh
@@ -1,14 +1,10 @@
 #!/bin/bash
 set -e
 
-GREEN="\033[0;32m"
-NO_COLOR='\033[0m'
-
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 cd $DIR
 
 echo "Flashing kernel..."
-tools/edl w boot_a output/boot.img
-tools/edl w boot_b output/boot.img
+tools/edl w boot_a $DIR/output/boot.img
 
-echo -e "${GREEN}Flashed boot_a and boot_b!${NO_COLOR}"
+echo "Done!"

--- a/flash_system.sh
+++ b/flash_system.sh
@@ -4,11 +4,17 @@ set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 cd $DIR
 
-echo "Flashing system..."
-tools/edl w system_a $DIR/output/system.img
+echo "Checking active slot..."
+ACTIVE_SLOT=$(tools/edl getactiveslot | grep "Current active slot:" | awk '{print $NF}')
 
-tools/edl setactiveslot a
-tools/edl setbootablestoragedrive 1
+if [[ "$ACTIVE_SLOT" != "a" && "$ACTIVE_SLOT" != "b" ]]; then
+  echo "Invalid active slot: '$ACTIVE_SLOT'"
+  exit 1
+fi
+
+echo "Active slot: $ACTIVE_SLOT"
+echo "Flashing system_$ACTIVE_SLOT..."
+tools/edl w system_$ACTIVE_SLOT $DIR/output/system.img
 
 tools/edl reset
 

--- a/flash_system.sh
+++ b/flash_system.sh
@@ -5,7 +5,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 cd $DIR
 
 echo "Flashing system..."
-tools/edl w system_a $DIR/output/system-skip-chunks.img
+tools/edl w system_a $DIR/output/system.img
 
 tools/edl setactiveslot a
 tools/edl setbootablestoragedrive 1

--- a/flash_system.sh
+++ b/flash_system.sh
@@ -18,4 +18,4 @@ tools/edl w system_$ACTIVE_SLOT $DIR/output/system.img
 
 tools/edl reset
 
-echo "Done!"
+echo "Flashed system_$ACTIVE_SLOT!"


### PR DESCRIPTION
- moving to `system.img` from `system-skip-chunks.img` (in order to remove `system-skip-chunks.img` later)
- `flash_kernel.sh` with `flash_system.sh` always flashes the active slot