### PR TITLE
support cursor server (vscode fork)

### DIFF
--- a/userspace/usr/comma/comma.sh
+++ b/userspace/usr/comma/comma.sh
@@ -63,7 +63,7 @@ fi
 # symlink vscode to userdata
 mkdir -p /data/tmp/vscode-server
 ln -s /data/tmp/vscode-server ~/.vscode-server
-
+ln -s /data/tmp/vscode-server ~/.cursor-server
 
 while true; do
   pkill -f "$SETUP"


### PR DESCRIPTION
I use [Cursor](https://www.cursor.com) instead of VSCode and on every boot (or AGNOS reflash) I need to link `.cursor-server`.

It uses the same temporary `vscode-server` directory.