### PR TITLE
also checkout submodules

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         lfs: true
+        submodules: true
 
     - name: Get commit message
       run: |


### PR DESCRIPTION
Now since there are no other private submodules, we can let `actions/checkout` pull `agnos-kernel-sdm845` which is much faster since it's with `--depth=1` vs `build_kernel.sh` which clones the whole repo.