### PR TITLE
Fix SecretsUsedInArgOrEnv warning

### DIFF
--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -14,9 +14,7 @@ RUN mkdir -p /tmp/agnos
 # Stop on error
 RUN set -xe
 
-ENV USERNAME=comma
-ENV PASSWD=comma
-ENV HOST=comma
+ARG USERNAME=comma
 
 # Base system setup
 RUN echo "resolvconf resolvconf/linkify-resolvconf boolean false" | debconf-set-selections


### PR DESCRIPTION
Address SecretsUsedInArgOrEnv warning

Secrets should not be saved in environment variable as they will be available also on the device. In this case they are anyway known and not critical, but they are not even used in the build process or later on the device. So IMHO better to remove them completely.