### PR TITLE
Fix InvalidBaseImagePlatform warning on aarch64

### DIFF
--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -4,10 +4,6 @@
 FROM scratch AS agnos-base
 ADD ubuntu-base-20.04.1-base-arm64.tar.gz /
 
-# Add aarch64 and arm support
-COPY --from=multiarch/qemu-user-static:x86_64-aarch64 /usr/bin/qemu-aarch64-static /usr/bin
-COPY --from=multiarch/qemu-user-static:x86_64-arm /usr/bin/qemu-arm-static /usr/bin
-
 # Build folder
 RUN mkdir -p /tmp/agnos
 

--- a/build_system.sh
+++ b/build_system.sh
@@ -36,10 +36,10 @@ if [ ! -f $UBUNTU_FILE ]; then
   curl -C - -o $UBUNTU_FILE $UBUNTU_BASE_URL/$UBUNTU_FILE --silent --remote-time
 fi
 
-# Register qemu multiarch
+# Setup qemu multiarch
 if [ "$ARCH" = "x86_64" ]; then
   echo "Registering qemu-user-static"
-  docker run --rm --privileged multiarch/qemu-user-static:register --reset > /dev/null
+  docker run --rm --privileged multiarch/qemu-user-static --reset -p yes > /dev/null
 fi
 
 # Start agnos-builder docker build and create container


### PR DESCRIPTION
Including the `qemu-aarch64-static` and `qemu-arm-static` binaries is not necessary, if `docker run --rm --privileged multiarch/qemu-user-static --reset -p yes` is executed before building the docker image. Only running it for x86_64 machines also fixes the `InvalidBaseImagePlatform ` warning.