### PR TITLE
Replace apt-get with apt-fast

### DIFF
--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -22,7 +22,7 @@ RUN /tmp/agnos/base_setup.sh
 # ################## #
 FROM agnos-base AS agnos-compiler
 
-RUN apt-fast update && apt-fast install --no-install-recommends checkinstall
+RUN apt-fast update && apt-fast install --no-install-recommends -yq checkinstall
 # Install openpilot dependencies, probably needed for build,
 # but we don't want these in the base image
 COPY ./userspace/openpilot_dependencies.sh /tmp/agnos/

--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -22,7 +22,7 @@ RUN /tmp/agnos/base_setup.sh
 # ################## #
 FROM agnos-base AS agnos-compiler
 
-RUN apt-get update && apt-get install --no-install-recommends checkinstall
+RUN apt-fast update && apt-fast install --no-install-recommends checkinstall
 # Install openpilot dependencies, probably needed for build,
 # but we don't want these in the base image
 COPY ./userspace/openpilot_dependencies.sh /tmp/agnos/

--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -11,10 +11,14 @@ touch /AGNOS
 # Add armhf as supported architecture
 dpkg --add-architecture armhf
 
+# Install apt-fast
+apt-get update
+apt-get install -yq curl sudo wget
+bash -c "$(curl -sL https://git.io/vokNn)"
+
 # Install packages
 export DEBIAN_FRONTEND=noninteractive
-apt-get update
-apt-get install -yq locales systemd adduser
+apt-fast install --no-install-recommends -yq locales systemd adduser
 
 # Create privileged user
 useradd -G sudo -m -s /bin/bash $USERNAME
@@ -46,8 +50,8 @@ echo "comma - nice -10" >> /etc/security/limits.conf
 locale-gen en_US.UTF-8
 update-locale LANG=en_US.UTF-8
 
-apt-get upgrade -yq
-apt-get install --no-install-recommends -yq \
+apt-fast upgrade -yq
+apt-fast install --no-install-recommends -yq \
     alsa-utils \
     apport-retrace \
     bc \
@@ -124,8 +128,8 @@ echo "comma ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 ln -sf /bin/bash /bin/sh
 
 # Install necessary libs
-apt-get update -yq
-apt-get install --no-install-recommends -yq \
+apt-fast update -yq
+apt-fast install --no-install-recommends -yq \
     libacl1:armhf \
     libasan5-armhf-cross \
     libatomic1-armhf-cross \

--- a/userspace/compile-modemmanager.sh
+++ b/userspace/compile-modemmanager.sh
@@ -7,16 +7,16 @@ PROVIDER_INFO_VERSION="20230416"
 
 cd /tmp
 
-apt update
-apt install -y --no-install-recommends automake autoconf build-essential cmake
+apt-fast update
+apt-fast install -y --no-install-recommends automake autoconf build-essential cmake
 
 # TODO: clean up these build time dependencies
-apt install -y --no-install-recommends python3 python3-pip python3-setuptools python3-wheel ninja-build
+apt-fast install -y --no-install-recommends python3 python3-pip python3-setuptools python3-wheel ninja-build
 pip3 install --user meson
 export PATH=$PATH:/root/.local/bin
 
 # build mobile-broadband-provider-info
-apt install -y --no-install-recommends xsltproc
+apt-fast install -y --no-install-recommends xsltproc
 git clone -b $PROVIDER_INFO_VERSION --depth 1 https://gitlab.gnome.org/GNOME/mobile-broadband-provider-info.git
 cd mobile-broadband-provider-info
 ./autogen.sh
@@ -25,7 +25,7 @@ make install
 
 # build libqmi
 cd /tmp
-apt install -y --no-install-recommends libgudev-1.0-dev gobject-introspection libgirepository1.0-dev help2man bash-completion
+apt-fast install -y --no-install-recommends libgudev-1.0-dev gobject-introspection libgirepository1.0-dev help2man bash-completion
 
 git clone -b $LIBQMI_VERSION --depth 1 https://gitlab.freedesktop.org/mobile-broadband/libqmi.git
 cd libqmi

--- a/userspace/install_extras.sh
+++ b/userspace/install_extras.sh
@@ -2,7 +2,7 @@
 
 # for all the non-essential nice to haves
 
-apt-get update && apt-get install -y --no-install-recommends \
+apt-fast update && apt-fast install -y --no-install-recommends \
   irqtop \
   ripgrep \
   nfs-common

--- a/userspace/openpilot_dependencies.sh
+++ b/userspace/openpilot_dependencies.sh
@@ -3,8 +3,8 @@
 echo "Installing openpilot dependencies"
 
 # Install necessary libs
-apt-get update
-apt-get install --no-install-recommends -yq \
+apt-fast update
+apt-fast install --no-install-recommends -yq \
     autoconf \
     automake \
     build-essential \


### PR DESCRIPTION
Use apt-fast instead of apt-get. This will speed up the build process especially when the apt package downloads are slow.