### PR TITLE
Remove apt cache for each layer

### DIFF
--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -106,8 +106,6 @@ apt-fast install --no-install-recommends -yq \
     wireless-tools \
     zlib1g-dev
 
-rm -rf /var/lib/apt/lists/*
-
 # Allow chrony to make a big adjustment to system time on boot
 echo "makestep 0.1 3" >> /etc/chrony/chrony.conf
 
@@ -128,7 +126,6 @@ echo "comma ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 ln -sf /bin/bash /bin/sh
 
 # Install necessary libs
-apt-fast update -yq
 apt-fast install --no-install-recommends -yq \
     libacl1:armhf \
     libasan5-armhf-cross \
@@ -207,4 +204,6 @@ apt-fast install --no-install-recommends -yq \
     wpasupplicant \
     hostapd \
     libgtk2.0-dev \
-    libxml2:armhf \
+    libxml2:armhf
+
+rm -rf /var/lib/apt/lists/*

--- a/userspace/compile-modemmanager.sh
+++ b/userspace/compile-modemmanager.sh
@@ -61,3 +61,5 @@ mkdir -p /tmp/mm-plugins
 mv /usr/lib/aarch64-linux-gnu/ModemManager/libmm-*.so /tmp/mm-plugins
 cp /tmp/mm-plugins/*generic* /usr/lib/aarch64-linux-gnu/ModemManager/
 cp /tmp/mm-plugins/*quectel* /usr/lib/aarch64-linux-gnu/ModemManager/
+
+rm -rf /var/lib/apt/lists/*

--- a/userspace/install_extras.sh
+++ b/userspace/install_extras.sh
@@ -9,3 +9,5 @@ apt-fast update && apt-fast install -y --no-install-recommends \
 
 # color prompt
 sed -i 's/#force_color_prompt=yes/force_color_prompt=yes/g' /home/comma/.bashrc
+
+rm -rf /var/lib/apt/lists/*

--- a/userspace/openpilot_dependencies.sh
+++ b/userspace/openpilot_dependencies.sh
@@ -75,3 +75,5 @@ apt-fast install --no-install-recommends -yq \
     qtpositioning5-dev \
     qtwayland5 \
     zstd
+
+rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Remove cached apt-related files after each build step that includes apt package installations. This reduces the size of the final docker image from 6.61GB to 5.85GB.
Note: It does NOT affect the size of the final system.img