### PR TITLE
Build PyQt5 wheel in parallel

### DIFF
--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -40,6 +40,12 @@ FROM agnos-base AS agnos-compiler
 RUN apt-fast update && apt-fast install --no-install-recommends -yq checkinstall
 
 # Individual compiling images
+FROM agnos-compiler AS agnos-compiler-pyqt5
+COPY ./userspace/openpilot_python_dependencies.sh /tmp/agnos/
+RUN /tmp/agnos/openpilot_python_dependencies.sh
+COPY ./userspace/compile-pyqt5.sh /tmp/agnos/
+RUN /tmp/agnos/compile-pyqt5.sh
+
 FROM agnos-compiler AS agnos-compiler-capnp
 COPY ./userspace/compile-capnp.sh /tmp/agnos/
 RUN /tmp/agnos/compile-capnp.sh
@@ -80,13 +86,16 @@ RUN /tmp/agnos/openpilot_python_dependencies.sh
 COPY --from=agnos-compiler-ffmpeg /tmp/ffmpeg.deb /tmp/ffmpeg.deb
 RUN cd /tmp && apt-get -o Dpkg::Options::="--force-overwrite" install -yq ./ffmpeg.deb
 
+# Use pre-compiled PyQt5 wheel
+COPY --from=agnos-compiler-pyqt5 /tmp/PyQt5-5.15.9/PyQt5-5.15.9-cp38-abi3-manylinux_2_17_aarch64.whl /tmp/PyQt5-5.15.9.whl
+
 RUN export PATH="/usr/local/pyenv/bin:/usr/local/pyenv/shims:$PATH" && \
     export PYENV_ROOT="/usr/local/pyenv" && \
     eval "$(pyenv init -)" && \
     eval "$(pyenv virtualenv-init -)" && \
     export MAKEFLAGS="-j$(nproc)" && \
     pip install pyqt5-sip==12.12.1 && \
-    pip install pyqt5==5.15.9 --verbose --config-settings --confirm-license= && \
+    pip install /tmp/PyQt5-5.15.9.whl --verbose --config-settings --confirm-license= && \
     pyenv rehash
 
 # Install openpilot python packages

--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -22,6 +22,8 @@ RUN /tmp/agnos/base_setup.sh
 # Install openpilot dependencies
 COPY ./userspace/openpilot_dependencies.sh /tmp/agnos/
 RUN /tmp/agnos/openpilot_dependencies.sh
+COPY ./userspace/openpilot_python_dependencies.sh /tmp/agnos/
+RUN /tmp/agnos/openpilot_python_dependencies.sh
 
 # Install old Qt 5.12.8, libwayland 1.9.0-1 and deps
 COPY ./userspace/qtwayland/*.deb /tmp/agnos/
@@ -41,8 +43,6 @@ RUN apt-fast update && apt-fast install --no-install-recommends -yq checkinstall
 
 # Individual compiling images
 FROM agnos-compiler AS agnos-compiler-pyqt5
-COPY ./userspace/openpilot_python_dependencies.sh /tmp/agnos/
-RUN /tmp/agnos/openpilot_python_dependencies.sh
 COPY ./userspace/compile-pyqt5.sh /tmp/agnos/
 RUN /tmp/agnos/compile-pyqt5.sh
 
@@ -78,9 +78,6 @@ RUN /tmp/agnos/compile-modemmanager.sh
 # Pre-compiled capnp (must be before python install)
 COPY --from=agnos-compiler-capnp /tmp/capnproto.deb /tmp/capnproto.deb
 RUN cd /tmp && apt-get -o Dpkg::Options::="--force-overwrite" install -yq ./capnproto.deb
-
-COPY ./userspace/openpilot_python_dependencies.sh /tmp/agnos/
-RUN /tmp/agnos/openpilot_python_dependencies.sh
 
 # Use other pre-compiled packages
 COPY --from=agnos-compiler-ffmpeg /tmp/ffmpeg.deb /tmp/ffmpeg.deb

--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -87,7 +87,7 @@ COPY --from=agnos-compiler-ffmpeg /tmp/ffmpeg.deb /tmp/ffmpeg.deb
 RUN cd /tmp && apt-get -o Dpkg::Options::="--force-overwrite" install -yq ./ffmpeg.deb
 
 # Use pre-compiled PyQt5 wheel
-COPY --from=agnos-compiler-pyqt5 /tmp/PyQt5-5.15.9/PyQt5-5.15.9-cp38-abi3-manylinux_2_17_aarch64.whl /tmp/PyQt5-5.15.9.whl
+COPY --from=agnos-compiler-pyqt5 /tmp/PyQt5-5.15.9/PyQt5-5.15.9-cp38-abi3-manylinux_2_17_aarch64.whl /tmp/PyQt5-5.15.9-cp38-abi3-manylinux_2_17_aarch64.whl
 
 RUN export PATH="/usr/local/pyenv/bin:/usr/local/pyenv/shims:$PATH" && \
     export PYENV_ROOT="/usr/local/pyenv" && \
@@ -95,7 +95,7 @@ RUN export PATH="/usr/local/pyenv/bin:/usr/local/pyenv/shims:$PATH" && \
     eval "$(pyenv virtualenv-init -)" && \
     export MAKEFLAGS="-j$(nproc)" && \
     pip install pyqt5-sip==12.12.1 && \
-    pip install /tmp/PyQt5-5.15.9.whl --verbose --config-settings --confirm-license= && \
+    pip install /tmp/PyQt5-5.15.9-cp38-abi3-manylinux_2_17_aarch64.whl --verbose --config-settings --confirm-license= && \
     pyenv rehash
 
 # Install openpilot python packages

--- a/userspace/compile-pyqt5.sh
+++ b/userspace/compile-pyqt5.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+# Use pyenv venv
+export PATH="/usr/local/pyenv/bin:/usr/local/pyenv/shims:$PATH"
+export PYENV_ROOT="/usr/local/pyenv"
+eval "$(pyenv init -)"
+eval "$(pyenv virtualenv-init -)"
+
+# Build PyQt5 wheel
+cd /tmp
+wget https://files.pythonhosted.org/packages/5c/46/b4b6eae1e24d9432905ef1d4e7c28b6610e28252527cdc38f2a75997d8b5/PyQt5-5.15.9.tar.gz
+tar xf PyQt5-5.15.9.tar.gz
+cd PyQt5-5.15.9
+
+export MAKEFLAGS="-j$(nproc)"
+pip wheel -w . --verbose --config-settings --confirm-license= .


### PR DESCRIPTION
Build PyQt5 wheel in parallel to other compilation steps and install from wheel later.
This reduces the overall Docker build time and makes better use of the Docker build cache.

Tests: Builds and runs on C3. Openpilot compiles, GUI works. (Not tested on-road)