### PR TITLE
Hang up console before serial-getty start

### DIFF
--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -126,6 +126,7 @@ COPY ./userspace/files/*.path /lib/systemd/system/
 COPY ./userspace/files/*.mount /lib/systemd/system/
 COPY ./userspace/files/*.service /lib/systemd/system/
 COPY ./userspace/files/*.timer /lib/systemd/system/
+COPY ./userspace/files/serial-getty@ttyMSM0_override.conf /lib/systemd/system/serial-getty@ttyMSM0.service.d/serial-getty@ttyMSM0_override.conf
 COPY ./userspace/files/ssh_override.conf /lib/systemd/system/ssh.service.d/override.conf
 COPY ./userspace/firmware/* /lib/firmware/
 

--- a/userspace/files/serial-getty@ttyMSM0_override.conf
+++ b/userspace/files/serial-getty@ttyMSM0_override.conf
@@ -1,0 +1,4 @@
+# With Ubuntu 24.04 (systemd 255) and 4.9 Kernel, the console is not properly 
+# hung up when the serial getty for ttyMSM0 is started. Force hangup with this.
+[Service]
+ExecStartPre=/bin/stty -F /dev/ttyMSM0 hupcl


### PR DESCRIPTION
In Ubuntu 24.04 (systemd 255) and Kernel 4.9 the boot console is not properly hung up before the start of serial-getty@ttyMSM0. In this state, kernel messages will continue to be printed to the serial console.
By sending another hupcl (Hang Up on Close) using stty, we can force the hangup and kernel messages will be properly handled by systemd and written to the appropriate log files without appearing on screen. 
This fixes #319.