### PR TITLE
[WIP] Cleanup base setup

### DIFF
--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -14,6 +14,8 @@ RUN set -xe
 
 ARG USERNAME=comma
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Base system setup
 RUN echo "resolvconf resolvconf/linkify-resolvconf boolean false" | debconf-set-selections
 COPY ./userspace/base_setup.sh /tmp/agnos

--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -21,6 +21,10 @@ RUN echo "resolvconf resolvconf/linkify-resolvconf boolean false" | debconf-set-
 COPY ./userspace/base_setup.sh /tmp/agnos
 RUN /tmp/agnos/base_setup.sh
 
+# Additional libraries
+COPY ./userspace/install_libraries.sh /tmp/agnos
+RUN /tmp/agnos/install_libraries.sh
+
 # Install openpilot dependencies
 COPY ./userspace/openpilot_dependencies.sh /tmp/agnos/
 RUN /tmp/agnos/openpilot_dependencies.sh

--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -17,7 +17,6 @@ apt-get install -yq curl sudo wget
 bash -c "$(curl -sL https://git.io/vokNn)"
 
 # Install packages
-export DEBIAN_FRONTEND=noninteractive
 apt-fast install --no-install-recommends -yq locales systemd adduser
 
 # Create privileged user

--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -53,46 +53,54 @@ apt-fast install --no-install-recommends -yq \
     bc \
     build-essential \
     bzip2 \
-    curl \
     chrony \
     cpuset \
+    curl \
     dfu-util \
+    dnsmasq-base \
     evtest \
+    gdb \
     git \
     git-core \
     git-lfs \
-    gdb \
+    hostapd \
     htop \
     i2c-tools \
     ifmetric \
     ifupdown \
     iptables-persistent \
+    iputils-ping \
+    isc-dhcp-client \
     jq \
+    kmod \
     landscape-common \
     libqmi-utils \
     libtool \
     llvm \
     nano \
     net-tools \
-    nload \
     network-manager \
+    nload \
     nvme-cli \
+    openssh-server \
     openssl \
     ppp \
+    rsyslog \
     smartmontools \
     speedtest-cli \
     ssh \
     sshfs \
     sudo \
     systemd-resolved \
-    traceroute \
     tk-dev \
+    traceroute \
     ubuntu-server \
     ubuntu-standard \
     udev \
     udhcpc \
     wget \
-    wireless-tools
+    wireless-tools \
+    wpasupplicant
 
 rm -rf /var/lib/apt/lists/*
 
@@ -111,15 +119,3 @@ echo "comma ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 # setup /bin/sh symlink
 ln -sf /bin/bash /bin/sh
-
-# Install necessary libs
-apt-fast update -yq
-apt-fast install --no-install-recommends -yq \
-    openssh-server \
-    dnsmasq-base \
-    isc-dhcp-client \
-    iputils-ping \
-    rsyslog \
-    kmod \
-    wpasupplicant \
-    hostapd

--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -17,9 +17,6 @@ apt-get upgrade -yq
 
 apt-fast install -yq --no-install-recommends ubuntu-minimal
 
-# Install packages
-apt-fast install --no-install-recommends -yq locales systemd adduser
-
 # Create privileged user
 useradd -G sudo -m -s /bin/bash $USERNAME
 echo "$USERNAME:$PASSWD" | chpasswd

--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -13,6 +13,10 @@ apt-get update
 apt-get install --no-install-recommends -yq ca-certificates wget
 bash -c "$(wget -qO- https://git.io/vokNn)"
 
+apt-get upgrade -yq
+
+apt-fast install -yq --no-install-recommends ubuntu-minimal
+
 # Install packages
 apt-fast install --no-install-recommends -yq locales systemd adduser
 
@@ -46,7 +50,6 @@ echo "comma - nice -10" >> /etc/security/limits.conf
 locale-gen en_US.UTF-8
 update-locale LANG=en_US.UTF-8
 
-apt-fast upgrade -yq
 apt-fast install --no-install-recommends -yq \
     alsa-utils \
     apport-retrace \
@@ -87,7 +90,6 @@ apt-fast install --no-install-recommends -yq \
     systemd-resolved \
     traceroute \
     tk-dev \
-    ubuntu-minimal \
     ubuntu-server \
     ubuntu-standard \
     udev \

--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -92,8 +92,7 @@ apt-fast install --no-install-recommends -yq \
     udev \
     udhcpc \
     wget \
-    wireless-tools \
-    zlib1g-dev
+    wireless-tools
 
 rm -rf /var/lib/apt/lists/*
 

--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -8,9 +8,6 @@ HOST=comma
 touch /TICI
 touch /AGNOS
 
-# Add armhf as supported architecture
-dpkg --add-architecture armhf
-
 # Install apt-fast
 apt-get update
 apt-get install -yq curl sudo wget
@@ -72,16 +69,8 @@ apt-fast install --no-install-recommends -yq \
     iptables-persistent \
     jq \
     landscape-common \
-    libi2c-dev \
     libqmi-utils \
     libtool \
-    libncursesw5-dev \
-    libnss-myhostname \
-    libgdbm-dev \
-    libc6-dev \
-    libsqlite3-dev \
-    libssl-dev \
-    libffi-dev \
     llvm \
     nano \
     net-tools \
@@ -128,69 +117,6 @@ ln -sf /bin/bash /bin/sh
 # Install necessary libs
 apt-fast update -yq
 apt-fast install --no-install-recommends -yq \
-    libacl1:armhf \
-    libasan6-armhf-cross \
-    libatomic1-armhf-cross \
-    libattr1:armhf \
-    libaudit1:armhf \
-    libblkid1:armhf \
-    libc6:armhf \
-    libc6-armhf-cross \
-    libc6-dev:armhf \
-    libc6-dev-armhf-cross \
-    libcairo2:armhf \
-    libcap2:armhf \
-    libdrm2:armhf \
-    libevdev2:armhf \
-    libexpat1:armhf \
-    libffi8:armhf \
-    libfontconfig1:armhf \
-    libfreetype6:armhf \
-    libgbm1:armhf \
-    libgcc-11-dev-armhf-cross \
-    libglib2.0-0t64:armhf \
-    libgomp1-armhf-cross \
-    libgudev-1.0-0:armhf \
-    libinput-bin:armhf \
-    libinput-dev:armhf \
-    libinput10:armhf \
-    libjpeg-dev:armhf \
-    libjpeg-turbo8:armhf \
-    libjpeg-turbo8-dev:armhf \
-    libjpeg8:armhf \
-    libjpeg8-dev:armhf \
-    libkmod2:armhf \
-    libmtdev1t64:armhf \
-    libpam0g:armhf \
-    libpam0g-dev:armhf \
-    libpcre3:armhf \
-    libpixman-1-0:armhf \
-    libpng16-16t64:armhf \
-    libselinux1:armhf \
-    libstdc++6:armhf \
-    libstdc++6-armhf-cross \
-    libubsan1-armhf-cross \
-    libudev-dev:armhf \
-    libudev1:armhf \
-    libuuid1:armhf \
-    libwacom9:armhf \
-    libx11-6:armhf \
-    libxau6:armhf \
-    libxcb-render0:armhf \
-    libxcb-shm0:armhf \
-    libxcb1:armhf \
-    libxdmcp6:armhf \
-    libxext6:armhf \
-    libxkbcommon0:armhf \
-    libxrender1:armhf \
-    linux-libc-dev:armhf \
-    linux-libc-dev-armhf-cross \
-    zlib1g:armhf \
-    libegl1 \
-    libegl-dev \
-    libgles1 \
-    libgles2 \
-    libgles-dev \
     openssh-server \
     dnsmasq-base \
     isc-dhcp-client \
@@ -198,6 +124,4 @@ apt-fast install --no-install-recommends -yq \
     rsyslog \
     kmod \
     wpasupplicant \
-    hostapd \
-    libgtk2.0-dev \
-    libxml2:armhf \
+    hostapd

--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -10,8 +10,8 @@ touch /AGNOS
 
 # Install apt-fast
 apt-get update
-apt-get install -yq curl sudo wget
-bash -c "$(curl -sL https://git.io/vokNn)"
+apt-get install --no-install-recommends -yq ca-certificates wget
+bash -c "$(wget -qO- https://git.io/vokNn)"
 
 # Install packages
 apt-fast install --no-install-recommends -yq locales systemd adduser

--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -61,7 +61,6 @@ apt-fast install --no-install-recommends -yq \
     evtest \
     gdb \
     git \
-    git-core \
     git-lfs \
     hostapd \
     htop \
@@ -69,10 +68,8 @@ apt-fast install --no-install-recommends -yq \
     ifmetric \
     ifupdown \
     iptables-persistent \
-    iputils-ping \
     isc-dhcp-client \
     jq \
-    kmod \
     landscape-common \
     libqmi-utils \
     libtool \
@@ -83,22 +80,18 @@ apt-fast install --no-install-recommends -yq \
     nload \
     nvme-cli \
     openssh-server \
-    openssl \
     ppp \
     rsyslog \
     smartmontools \
     speedtest-cli \
     ssh \
     sshfs \
-    sudo \
     systemd-resolved \
     tk-dev \
     traceroute \
     ubuntu-server \
     ubuntu-standard \
-    udev \
     udhcpc \
-    wget \
     wireless-tools \
     wpasupplicant
 

--- a/userspace/install_libraries.sh
+++ b/userspace/install_libraries.sh
@@ -14,6 +14,7 @@ apt-fast update && apt-fast install --no-install-recommends -yq \
     libsqlite3-dev \
     libssl-dev \
     libffi-dev \
+    zlib1g-dev \
     libacl1:armhf \
     libasan6-armhf-cross \
     libatomic1-armhf-cross \

--- a/userspace/install_libraries.sh
+++ b/userspace/install_libraries.sh
@@ -1,0 +1,81 @@
+#!/bin/bash -e
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Add armhf as supported architecture
+dpkg --add-architecture armhf
+
+apt-fast update && apt-fast install --no-install-recommends -yq \
+    libi2c-dev \
+    libncursesw5-dev \
+    libnss-myhostname \
+    libgdbm-dev \
+    libc6-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    libffi-dev \
+    libacl1:armhf \
+    libasan6-armhf-cross \
+    libatomic1-armhf-cross \
+    libattr1:armhf \
+    libaudit1:armhf \
+    libblkid1:armhf \
+    libc6:armhf \
+    libc6-armhf-cross \
+    libc6-dev:armhf \
+    libc6-dev-armhf-cross \
+    libcairo2:armhf \
+    libcap2:armhf \
+    libdrm2:armhf \
+    libevdev2:armhf \
+    libexpat1:armhf \
+    libffi8:armhf \
+    libfontconfig1:armhf \
+    libfreetype6:armhf \
+    libgbm1:armhf \
+    libgcc-11-dev-armhf-cross \
+    libglib2.0-0t64:armhf \
+    libgomp1-armhf-cross \
+    libgudev-1.0-0:armhf \
+    libinput-bin:armhf \
+    libinput-dev:armhf \
+    libinput10:armhf \
+    libjpeg-dev:armhf \
+    libjpeg-turbo8:armhf \
+    libjpeg-turbo8-dev:armhf \
+    libjpeg8:armhf \
+    libjpeg8-dev:armhf \
+    libkmod2:armhf \
+    libmtdev1t64:armhf \
+    libpam0g:armhf \
+    libpam0g-dev:armhf \
+    libpcre3:armhf \
+    libpixman-1-0:armhf \
+    libpng16-16t64:armhf \
+    libselinux1:armhf \
+    libstdc++6:armhf \
+    libstdc++6-armhf-cross \
+    libubsan1-armhf-cross \
+    libudev-dev:armhf \
+    libudev1:armhf \
+    libuuid1:armhf \
+    libwacom9:armhf \
+    libx11-6:armhf \
+    libxau6:armhf \
+    libxcb-render0:armhf \
+    libxcb-shm0:armhf \
+    libxcb1:armhf \
+    libxdmcp6:armhf \
+    libxext6:armhf \
+    libxkbcommon0:armhf \
+    libxrender1:armhf \
+    linux-libc-dev:armhf \
+    linux-libc-dev-armhf-cross \
+    zlib1g:armhf \
+    libegl1 \
+    libegl-dev \
+    libgles1 \
+    libgles2 \
+    libgles-dev \
+    libgtk2.0-dev \
+    libxml2:armhf \

--- a/userspace/install_libraries.sh
+++ b/userspace/install_libraries.sh
@@ -6,56 +6,61 @@ export DEBIAN_FRONTEND=noninteractive
 dpkg --add-architecture armhf
 
 apt-fast update && apt-fast install --no-install-recommends -yq \
-    libi2c-dev \
-    libncursesw5-dev \
-    libnss-myhostname \
-    libgdbm-dev \
-    libc6-dev \
-    libsqlite3-dev \
-    libssl-dev \
-    libffi-dev \
-    zlib1g-dev \
     libacl1:armhf \
     libasan6-armhf-cross \
     libatomic1-armhf-cross \
     libattr1:armhf \
     libaudit1:armhf \
     libblkid1:armhf \
-    libc6:armhf \
     libc6-armhf-cross \
-    libc6-dev:armhf \
+    libc6-dev \
     libc6-dev-armhf-cross \
+    libc6-dev:armhf \
+    libc6:armhf \
     libcairo2:armhf \
     libcap2:armhf \
     libdrm2:armhf \
+    libegl-dev \
+    libegl1 \
     libevdev2:armhf \
     libexpat1:armhf \
+    libffi-dev \
     libffi8:armhf \
     libfontconfig1:armhf \
     libfreetype6:armhf \
     libgbm1:armhf \
     libgcc-11-dev-armhf-cross \
+    libgdbm-dev \
+    libgles-dev \
+    libgles1 \
+    libgles2 \
     libglib2.0-0t64:armhf \
     libgomp1-armhf-cross \
+    libgtk2.0-dev \
     libgudev-1.0-0:armhf \
+    libi2c-dev \
     libinput-bin:armhf \
     libinput-dev:armhf \
     libinput10:armhf \
     libjpeg-dev:armhf \
-    libjpeg-turbo8:armhf \
     libjpeg-turbo8-dev:armhf \
-    libjpeg8:armhf \
+    libjpeg-turbo8:armhf \
     libjpeg8-dev:armhf \
+    libjpeg8:armhf \
     libkmod2:armhf \
     libmtdev1t64:armhf \
-    libpam0g:armhf \
+    libncursesw5-dev \
+    libnss-myhostname \
     libpam0g-dev:armhf \
+    libpam0g:armhf \
     libpcre3:armhf \
     libpixman-1-0:armhf \
     libpng16-16t64:armhf \
     libselinux1:armhf \
-    libstdc++6:armhf \
+    libsqlite3-dev \
+    libssl-dev \
     libstdc++6-armhf-cross \
+    libstdc++6:armhf \
     libubsan1-armhf-cross \
     libudev-dev:armhf \
     libudev1:armhf \
@@ -69,14 +74,9 @@ apt-fast update && apt-fast install --no-install-recommends -yq \
     libxdmcp6:armhf \
     libxext6:armhf \
     libxkbcommon0:armhf \
-    libxrender1:armhf \
-    linux-libc-dev:armhf \
-    linux-libc-dev-armhf-cross \
-    zlib1g:armhf \
-    libegl1 \
-    libegl-dev \
-    libgles1 \
-    libgles2 \
-    libgles-dev \
-    libgtk2.0-dev \
     libxml2:armhf \
+    libxrender1:armhf \
+    linux-libc-dev-armhf-cross \
+    linux-libc-dev:armhf \
+    zlib1g-dev \
+    zlib1g:armhf

--- a/userspace/install_libraries.sh
+++ b/userspace/install_libraries.sh
@@ -36,11 +36,11 @@ apt-fast update && apt-fast install --no-install-recommends -yq \
     libgles2 \
     libglib2.0-0t64:armhf \
     libgomp1-armhf-cross \
-    libgtk2.0-dev \
     libgudev-1.0-0:armhf \
     libi2c-dev \
     libinput-bin:armhf \
     libinput-dev:armhf \
+    libgtk2.0-dev \
     libinput10:armhf \
     libjpeg-dev:armhf \
     libjpeg-turbo8-dev:armhf \


### PR DESCRIPTION
`base_setup.sh` is not well maintained. This is especially an issue, as it is the first script in the docker build and any changes here forces a nearly complete rebuild.

With this PR, `base_setup.sh` will be cleaned up, so that it creates a bootable minimal Ubuntu with some connectivity, but not more. After this cleanup there shouldn't be any need to touch this file, except for major changes (e.g. mainline kernel).