### PR TITLE
Use shasum for macOS compatibility

### DIFF
--- a/build_system.sh
+++ b/build_system.sh
@@ -44,7 +44,7 @@ if [ ! -f $UBUNTU_FILE ]; then
 fi
 
 # Check SHA256 sum
-if [ "$(sha256sum "$UBUNTU_FILE" | awk '{print $1}')" != "$UBUNTU_FILE_CHECKSUM" ]; then
+if [ "$(shasum -a 256 "$UBUNTU_FILE" | awk '{print $1}')" != "$UBUNTU_FILE_CHECKSUM" ]; then
   echo "Checksum mismatch, please check Ubuntu releases: $UBUNTU_BASE_URL"
   exit 1
 fi


### PR DESCRIPTION
`sha256sum` does not exists in macOS, but `shasum -a 256` has the same functionality in both linux and maxOS.