### PR TITLE
Cleanup llvm and qemu packages

### DIFF
--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -203,6 +203,10 @@ RUN cd /usr/lib/gcc/arm-none-eabi/* && \
     rm -rf arm/ && \
     rm -rf thumb/nofp thumb/v6* thumb/v8* thumb/v7+fp thumb/v7-r+fp.sp
 
+# TODO: make these packages not get installed in the first time
+# qemu-user also removes libglib2.0-dev:armhf libgudev-1.0-dev:armhf libinput-dev:armhf libwacom-dev:armhf
+RUN apt-fast update && apt-fast remove -y qemu-user:armhf
+
 # keep this last
 RUN ldconfig
 
@@ -219,7 +223,7 @@ COPY ./userspace/files/apt.conf /etc/apt/apt.conf
 COPY VERSION /VERSION
 
 # ################## #
-# #### Cleaunup #### #
+# #### Cleanup #### #
 # ################## #
 
 RUN rm -rf /usr/share/icons/* && \

--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -112,6 +112,12 @@ apt-fast install --no-install-recommends -yq \
 apt-fast install --no-install-recommends -yq \
     clang-17 \
     llvm-17
+# since all files are suffixed with "-17", just remove the suffix
+for file in /usr/bin/*-17; do
+    if [ -f "$file" ]; then
+        mv "$file" "$(echo "$file" | sed 's/-17$//')"
+    fi
+done
 
 rm -rf /var/lib/apt/lists/*
 

--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -83,7 +83,6 @@ apt-fast install --no-install-recommends -yq \
     libsqlite3-dev \
     libssl-dev \
     libffi-dev \
-    llvm \
     nano \
     net-tools \
     nload \
@@ -107,6 +106,12 @@ apt-fast install --no-install-recommends -yq \
     wget \
     wireless-tools \
     zlib1g-dev
+
+# keep LLVM 17 (not 18 as in 24.04, since mesa/rusticl/etc seems to use 17)
+# clang & llvm metapackages install LLVM 18 (which is not installed anymore)
+apt-fast install --no-install-recommends -yq \
+    clang-17 \
+    llvm-17
 
 rm -rf /var/lib/apt/lists/*
 

--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -112,6 +112,7 @@ apt-fast install --no-install-recommends -yq \
 apt-fast install --no-install-recommends -yq \
     clang-17 \
     llvm-17
+
 # since all files are suffixed with "-17", just remove the suffix
 for file in /usr/bin/*-17; do
     if [ -f "$file" ]; then

--- a/userspace/openpilot_dependencies.sh
+++ b/userspace/openpilot_dependencies.sh
@@ -10,7 +10,6 @@ apt-fast install --no-install-recommends -yq \
     build-essential \
     bzip2 \
     casync \
-    clang \
     clinfo \
     cmake \
     cppcheck \
@@ -33,7 +32,6 @@ apt-fast install --no-install-recommends -yq \
     libi2c-dev \
     libjpeg-dev \
     liblzma-dev \
-    libomp-dev \
     libportaudio2 \
     libsdl2-dev \
     libsqlite3-dev \


### PR DESCRIPTION
Removes llvm/clang 18 and qemu-user and keeps llvm/clang 17.
