### PR TITLE
Use debhelper tools for dependency compilation and packaging

### DIFF
--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -42,7 +42,7 @@ RUN apt-get -o Dpkg::Options::="--force-overwrite" install -yq \
 # ################## #
 FROM agnos-base AS agnos-compiler
 
-RUN apt-fast update && apt-fast install --no-install-recommends -yq checkinstall
+RUN apt-fast update && apt-fast install --no-install-recommends -yq dh-make dpkg-dev
 
 # Individual compiling images
 FROM agnos-compiler AS agnos-compiler-pyqt5

--- a/userspace/compile-capnp.sh
+++ b/userspace/compile-capnp.sh
@@ -6,11 +6,15 @@ VERSION=1.0.2
 wget https://capnproto.org/capnproto-c++-${VERSION}.tar.gz
 tar xvf capnproto-c++-${VERSION}.tar.gz
 cd capnproto-c++-${VERSION}
-CXXFLAGS="-fPIC -O2" ./configure
 
-make -j$(nproc)
+export DEBFULLNAME=comma
+export LOGNAME=comma
 
-# remove "--fstrans=no" when checkinstall is fixed (still not fixed in 24.04)
-# https://bugs.launchpad.net/ubuntu/+source/checkinstall/+bug/78455
-checkinstall -yD --install=no --fstrans=no --pkgname=capnproto
-mv capnproto*.deb /tmp/capnproto.deb
+dh_make --createorig -s -p capnproto_${VERSION} -y
+
+echo -e "override_dh_auto_configure:\n\tCXX_FLAGS=\"-fPIC -O2\" ./configure" >> debian/rules
+echo -e "override_dh_usrlocal:" >> debian/rules
+
+DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -us -uc -nc
+
+mv ../capnproto*.deb /tmp/capnproto.deb

--- a/userspace/compile-ffmpeg.sh
+++ b/userspace/compile-ffmpeg.sh
@@ -6,15 +6,19 @@ wget https://ffmpeg.org/releases/ffmpeg-4.2.2.tar.bz2
 tar xvf ffmpeg-4.2.2.tar.bz2
 cd ffmpeg-4.2.2
 
+export DEBFULLNAME=comma
+export LOGNAME=comma
+
+dh_make --createorig -s -p ffmpeg_4.2.2 -y
+
 # avoid makeinfo: error parsing ./doc/t2h.pm: Undefined subroutine &Texinfo::Config::set_from_init_file called at ./doc/t2h.pm line 24.
 # with --disable-htmlpages
 # --disable-doc works too, disables building documentation completely
 # https://gist.github.com/omegdadi/6904512c0a948225c81114b1c5acb875
 # https://github.com/7Ji/archrepo/issues/10
-./configure --enable-shared --disable-static --disable-htmlpages
-make -j$(nproc)
+echo -e "override_dh_auto_configure:\n\t./configure --enable-shared --disable-static --disable-htmlpages" >> debian/rules
+echo -e "override_dh_usrlocal:" >> debian/rules
 
-# remove "--fstrans=no" when checkinstall is fixed (still not fixed in 24.04)
-# # https://bugs.launchpad.net/ubuntu/+source/checkinstall/+bug/78455
-checkinstall -yD --install=no --fstrans=no --pkgname=ffmpeg
-mv ffmpeg*.deb /tmp/ffmpeg.deb
+DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -us -uc -nc
+
+mv ../ffmpeg*.deb /tmp/ffmpeg.deb

--- a/userspace/compile-qtwayland5.sh
+++ b/userspace/compile-qtwayland5.sh
@@ -14,13 +14,14 @@ git apply /tmp/agnos/patch-qtwayland-v5.12
 # https://stackoverflow.com/a/75855054/639708
 ln -s libdl.so.2 /usr/lib/aarch64-linux-gnu/libdl.so
 
-mkdir /tmp/build && cd /tmp/build
-qmake /tmp/qtwayland
+export DEBFULLNAME=comma
+export LOGNAME=comma
 
-export MAKEFLAGS="-j$(nproc)"
-make
+dh_make --createorig -s -p qtwayland5_5.12.9 -y
 
-# remove "--fstrans=no" when checkinstall is fixed (still not fixed in 24.04)
-# # https://bugs.launchpad.net/ubuntu/+source/checkinstall/+bug/78455
-checkinstall -yD --install=no --fstrans=no --pkgversion="${VERSION}" --pkgname=qtwayland5 --pkgarch=arm64 --replaces=qtwayland5,libqt5waylandclient5,libqt5waylandcompositor5
-mv qtwayland5*.deb /tmp/qtwayland5.deb
+echo -e "override_dh_usrlocal:" >> debian/rules
+echo -e "override_dh_shlibdeps:\n\tdh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info" >> debian/rules
+
+DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -us -uc -nc
+
+mv ../qtwayland5*.deb /tmp/qtwayland5.deb


### PR DESCRIPTION
Use debhelper tools for creation of the .deb packages rather than old checkinstall.