### PR TITLE
Compile only necessary PyQt5 modules

### DIFF
--- a/userspace/compile-pyqt5.sh
+++ b/userspace/compile-pyqt5.sh
@@ -28,4 +28,4 @@ tar xf PyQt5-${VERSION}.tar.gz
 cd PyQt5-${VERSION}
 
 export MAKEFLAGS="-j$(nproc)"
-pip wheel -w . --verbose --config-settings --confirm-license= .
+pip wheel -w . --verbose --config-settings --confirm-license= --config-settings --enable=QtCore --config-settings --enable=QtWidgets .


### PR DESCRIPTION
Currently only QtCore and QtWidgers are in use. Disable all remaining modules to minimize compile time.