### PR TITLE
op alias

### DIFF
--- a/userspace/home/.bash_aliases
+++ b/userspace/home/.bash_aliases
@@ -7,4 +7,4 @@ alias gst='git status'
 alias gco='git checkout'
 alias gsu='git submodule update'
 alias dump="/data/pythonpath/selfdrive/debug/dump.py"
-
+alias op='/data/openpilot/tools/op.sh "$@"'


### PR DESCRIPTION
Resolves https://github.com/commaai/agnos-builder/issues/301

Tested `op build`, seems to work fine except that it starts building files (tools and tests) while `launch_openpilot.sh` / `build.py` doesn't do anything:
```
scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
scons: `.' is up to date.
scons: done building targets.
```