### PR TITLE
replace chrony with timesyncd

### DIFF
--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -58,7 +58,6 @@ apt-fast install --no-install-recommends -yq \
     build-essential \
     bzip2 \
     curl \
-    chrony \
     cpuset \
     dfu-util \
     evtest \
@@ -110,9 +109,6 @@ apt-fast install --no-install-recommends -yq \
     zlib1g-dev
 
 rm -rf /var/lib/apt/lists/*
-
-# Allow chrony to make a big adjustment to system time on boot
-echo "makestep 0.1 3" >> /etc/chrony/chrony.conf
 
 # Create dirs
 mkdir /data && chown $USERNAME:$USERNAME /data

--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -97,6 +97,7 @@ apt-fast install --no-install-recommends -yq \
     sshfs \
     sudo \
     systemd-resolved \
+    systemd-timesyncd \
     traceroute \
     tk-dev \
     ubuntu-minimal \


### PR DESCRIPTION
Resolves https://github.com/commaai/agnos-builder/issues/318
- removes chrony and replaces it with [systemd-timesyncd](https://wiki.archlinux.org/title/Systemd-timesyncd)
- makes time syncing faster than chrony and when network configuration or connectivity changes
- installed build and tested both with internet and without internet on boot - time is synced almost instantly after network connectivity is up

```
$ journalctl -u systemd-timesyncd
Aug 08 14:51:13 comma systemd[1]: Starting systemd-timesyncd.service - Network Time Synchronization...
Aug 08 14:51:13 comma (imesyncd)[2819]: systemd-timesyncd.service: ProtectHostname=yes is configured, but the kernel does not support UTS na>
Aug 08 14:51:13 comma systemd[1]: Started systemd-timesyncd.service - Network Time Synchronization.
Aug 08 14:51:13 comma systemd-timesyncd[2819]: No network connectivity, watching for changes.
Aug 08 14:54:47 comma-cb80a5fa systemd-timesyncd[2819]: Network configuration changed, trying to establish connection.
Sep 15 06:40:29 comma-cb80a5fa systemd-timesyncd[2819]: Contacted time server 185.125.190.57:123 (ntp.ubuntu.com).
Sep 15 06:40:29 comma-cb80a5fa systemd-timesyncd[2819]: Initial clock synchronization to Sun 2024-09-15 06:40:29.697339 UTC.
```