### PR TITLE
clear /data/tmp on boot

### DIFF
--- a/userspace/usr/comma/comma.sh
+++ b/userspace/usr/comma/comma.sh
@@ -61,8 +61,8 @@ elif ! mountpoint -q /data; then
 fi
 
 # setup /data/tmp
+rm -rf /data/tmp
 mkdir -p /data/tmp
-rm -rf /data/tmp/*
 
 # symlink vscode to userdata
 mkdir -p /data/tmp/vscode-server

--- a/userspace/usr/comma/comma.sh
+++ b/userspace/usr/comma/comma.sh
@@ -60,6 +60,10 @@ elif ! mountpoint -q /data; then
   fi
 fi
 
+# setup /data/tmp
+mkdir -p /data/tmp
+rm -rf /data/tmp/*
+
 # symlink vscode to userdata
 mkdir -p /data/tmp/vscode-server
 ln -s /data/tmp/vscode-server ~/.vscode-server


### PR DESCRIPTION
Resolves https://github.com/commaai/agnos-builder/issues/339

Alternative (by mounting to `/tmp` variant):
```
# setup /data/tmp
rm -rf /data/tmp
ln -s /tmp /data/tmp
```

Tested both variants on device by editing `/usr/comma/comma.sh` manually, touching some files in `/data/tmp` then restart and investigate the results.