### PR TITLE
Fix build on amd64 systems

### DIFF
--- a/build_system.sh
+++ b/build_system.sh
@@ -60,7 +60,7 @@ docker build -f Dockerfile.agnos --check $DIR
 
 # Start agnos-builder docker build and create container
 echo "Building agnos-builder docker image"
-docker build -f Dockerfile.agnos -t agnos-builder $DIR --build-arg UBUNTU_BASE_IMAGE=$UBUNTU_FILE
+docker build -f Dockerfile.agnos -t agnos-builder $DIR --build-arg UBUNTU_BASE_IMAGE=$UBUNTU_FILE --platform=linux/arm64
 echo "Creating agnos-builder container"
 CONTAINER_ID=$(docker container create --entrypoint /bin/bash agnos-builder:latest)
 


### PR DESCRIPTION
Explicitly set platform to linux/arm64. Without this linux/amd64 is used on amd64 systems, leading to a build failure.

Fixes https://github.com/commaai/agnos-builder/issues/370