### PR TITLE
make timesync persistent

### DIFF
--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -250,8 +250,12 @@ COPY ./userspace/files/apt.conf /etc/apt/apt.conf
 # copy version file
 COPY VERSION /VERSION
 
+# The modification time ("mtime") of this file is used for advancing the system clock in case /var/lib/systemd/timesync/clock does not exist yet
+# Sets initial boot time (as build time) and fixes fstab warning #374 (system time > fstab mtime)
+RUN touch /usr/lib/clock-epoch
+
 # ################## #
-# #### Cleaunup #### #
+# #### Cleanup #### #
 # ################## #
 
 RUN rm -rf /usr/share/icons/* && \

--- a/userspace/usr/comma/fs_setup.sh
+++ b/userspace/usr/comma/fs_setup.sh
@@ -9,6 +9,12 @@ touch /data/etc/timezone
 touch /data/etc/localtime
 mkdir -p /data/etc/NetworkManager/system-connections
 
+# /var
+mkdir -p /data/var/lib/systemd/timesync
+rm -rf /var/lib/systemd/timesync
+mkdir -p /var/lib/systemd
+ln -s /data/var/lib/systemd/timesync /var/lib/systemd
+
 # /data/media - NVME mount point
 mkdir -p /data/media
 


### PR DESCRIPTION
Fixes https://github.com/commaai/agnos-builder/issues/374 by:
- making the default system time to build time (by touching /usr/lib/clock-epoch) thus making the system time > /etc/fstab mtime (to prevent the fstab warning)
- symlinked timesyncd clock so that the last time set is set first at next boot
- validated by doing a couple of reboots and checking if 'systemctl daemon-reload' is requested
```
$ journalctl -u systemd-timesyncd
Sep 18 13:53:23 comma systemd[1]: Starting systemd-timesyncd.service - Network Time Synchronization...
Sep 18 13:53:23 comma (imesyncd)[3060]: systemd-timesyncd.service: ProtectHostname=yes is configured, but the kernel does not support UTS namespaces, ignoring namespace setup.
Sep 18 21:09:51 comma systemd-timesyncd[3060]: System clock time unset or jumped backwards, restored from recorded timestamp: Wed 2024-09-18 21:09:51 UTC
Sep 18 21:09:51 comma systemd[1]: Started systemd-timesyncd.service - Network Time Synchronization.
Sep 18 21:10:16 comma-cb80a5fa systemd-timesyncd[3060]: Network configuration changed, trying to establish connection.
Sep 18 21:10:29 comma-cb80a5fa systemd-timesyncd[3060]: Contacted time server 91.189.91.157:123 (ntp.ubuntu.com).
Sep 18 21:10:29 comma-cb80a5fa systemd-timesyncd[3060]: Initial clock synchronization to Wed 2024-09-18 21:10:29.738480 UTC.
$ sudo mount -o rw,remount /
$ 
```