### PR TITLE
Ensure parent directories exist for download-from-manifest.py

### DIFF
--- a/scripts/download-from-manifest.py
+++ b/scripts/download-from-manifest.py
@@ -13,6 +13,9 @@ RELEASE_MANIFEST = "https://raw.githubusercontent.com/commaai/openpilot/release3
 ROOT = Path(__file__).parent.parent
 
 def download_and_decompress(url, expected_hash, filename):
+  # Ensure parent directories exist
+  filename.parent.mkdir(parents=True, exist_ok=True)
+  
   # check if already downloaded
   if Path(filename).is_file():
     sha256 = hashlib.sha256()


### PR DESCRIPTION
https://discord.com/channels/469524606043160576/871838269405556736/1288752129594359860

output is expected to exist but isn't on a fresh clone.