### PR TITLE
`docs`: add mention of docker-buildx `>0.15.0` requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ This repo builds the two main parts of that (system and kernel) and packages it 
 
 Any system that supports a recent [Docker](https://docs.docker.com/get-docker/) should work.
 
+> [!NOTE]
+> docker buildx version >0.15.0 is required
+
 Run once to set things up:
 ```sh
 git clone https://github.com/commaai/agnos-builder.git


### PR DESCRIPTION
when wanting to run `build_system.sh` i run into this error:
```bash
└─(13:31:34 on master)──> ./build_system.sh                                                                                                            ──(Fri,Nov08)─┘
unknown flag: --check
See 'docker buildx build --help'.
```

This comes from having docker buildx 0.14.0:
```bash
─(13:34:24 on master)──> docker buildx version                                                           ──(Fri,Nov08)─┘
github.com/docker/buildx v0.14.0-desktop.1 7b0470cffd54ccbf42976d2f75febc4532c85073
```

After looking through the discord it was mentioned that `0.15.0` docker buildx is necessary since it includes the missing `--check` flag: https://discord.com/channels/469524606043160576/1262118077017882715/1271548206198820865

This was a bit of go and would help with mentioning this in the README