### PR TITLE
Fix uv installer version to 0.4.30

### DIFF
--- a/userspace/openpilot_python_dependencies.sh
+++ b/userspace/openpilot_python_dependencies.sh
@@ -1,11 +1,13 @@
 #!/bin/bash -e
 
+UV_VERSION=0.4.30
+
 echo "installing uv..."
 
 export XDG_DATA_HOME="/usr/local"
 export CARGO_HOME="$XDG_DATA_HOME/.cargo"
 
-curl -LsSf https://astral.sh/uv/install.sh | sh
+curl -LsSf https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-installer.sh | sh
 eval ". $CARGO_HOME/env"
 
 PYTHON_VERSION="3.12.3"


### PR DESCRIPTION
uv 0.5.0 introduced breaking changes to the installation process. So it's a good idea to fix the uv version in general to keep the agnos build from failing. uv can be updated to 0.5.x in a next step.