### PR TITLE
`build_system`: fix uv `5.1` error and `3.12` pkgconfig error

### DIFF
--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -125,7 +125,6 @@ COPY --from=agnos-compiler-ffmpeg /tmp/ffmpeg.deb /tmp/ffmpeg.deb
 RUN cd /tmp && apt-get -o Dpkg::Options::="--force-overwrite" install -yq ./ffmpeg.deb
 
 ARG XDG_DATA_HOME="/usr/local"
-ARG PATH="$XDG_DATA_HOME/.cargo/bin:$PATH"
 
 # Install openpilot python packages
 COPY ./userspace/uv /tmp/agnos/uv

--- a/userspace/openpilot_python_dependencies.sh
+++ b/userspace/openpilot_python_dependencies.sh
@@ -2,36 +2,11 @@
 
 echo "installing uv..."
 
-export XDG_DATA_HOME="/usr/local"
-UV_BIN="$HOME/.local/bin"
-PATH="$UV_BIN:$PATH"
+export XDG_DATA_HOME="/usr/local" # uv is installed in $XDG_DATA_HOME/../bin since 0.5.0
 
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# Create and activate virtual environment with specific Python version
-PYTHON_VERSION="3.12"
+PYTHON_VERSION="3.12.3"
+
+# uv requires virtual env either managed or system before installing dependencies
 uv venv $XDG_DATA_HOME/venv --seed --python-preference only-managed --python=$PYTHON_VERSION
-
-# Ensure the virtual environment is activated
-. $XDG_DATA_HOME/venv/bin/activate
-
-# Verify Python version and create pkg-config directory if needed
-python_path=$(python -c "import sys; print(sys.prefix)")
-mkdir -p "${python_path}/lib/pkgconfig"
-
-# Create the necessary pkg-config files
-cat > "${python_path}/lib/pkgconfig/python-${PYTHON_VERSION}.pc" << EOF
-prefix=${python_path}
-exec_prefix=\${prefix}
-libdir=\${exec_prefix}/lib
-includedir=\${prefix}/include
-
-Name: Python
-Description: Python library
-Version: ${PYTHON_VERSION}
-Libs: -L\${libdir} -lpython${PYTHON_VERSION}
-Cflags: -I\${includedir}/python${PYTHON_VERSION}
-EOF
-
-# Create embed version as well
-cp "${python_path}/lib/pkgconfig/python-${PYTHON_VERSION}.pc" "${python_path}/lib/pkgconfig/python-${PYTHON_VERSION}-embed.pc"

--- a/userspace/openpilot_python_dependencies.sh
+++ b/userspace/openpilot_python_dependencies.sh
@@ -3,12 +3,35 @@
 echo "installing uv..."
 
 export XDG_DATA_HOME="/usr/local"
-export CARGO_HOME="$XDG_DATA_HOME/.cargo"
+UV_BIN="$HOME/.local/bin"
+PATH="$UV_BIN:$PATH"
 
 curl -LsSf https://astral.sh/uv/install.sh | sh
-eval ". $CARGO_HOME/env"
 
-PYTHON_VERSION="3.12.3"
-
-# uv requires virtual env either managed or system before installing dependencies
+# Create and activate virtual environment with specific Python version
+PYTHON_VERSION="3.12"
 uv venv $XDG_DATA_HOME/venv --seed --python-preference only-managed --python=$PYTHON_VERSION
+
+# Ensure the virtual environment is activated
+. $XDG_DATA_HOME/venv/bin/activate
+
+# Verify Python version and create pkg-config directory if needed
+python_path=$(python -c "import sys; print(sys.prefix)")
+mkdir -p "${python_path}/lib/pkgconfig"
+
+# Create the necessary pkg-config files
+cat > "${python_path}/lib/pkgconfig/python-${PYTHON_VERSION}.pc" << EOF
+prefix=${python_path}
+exec_prefix=\${prefix}
+libdir=\${exec_prefix}/lib
+includedir=\${prefix}/include
+
+Name: Python
+Description: Python library
+Version: ${PYTHON_VERSION}
+Libs: -L\${libdir} -lpython${PYTHON_VERSION}
+Cflags: -I\${includedir}/python${PYTHON_VERSION}
+EOF
+
+# Create embed version as well
+cp "${python_path}/lib/pkgconfig/python-${PYTHON_VERSION}.pc" "${python_path}/lib/pkgconfig/python-${PYTHON_VERSION}-embed.pc"

--- a/userspace/openpilot_python_dependencies.sh
+++ b/userspace/openpilot_python_dependencies.sh
@@ -2,7 +2,7 @@
 
 echo "installing uv..."
 
-export XDG_DATA_HOME="/usr/local" # uv is installed in $XDG_DATA_HOME/../bin since 0.5.0
+export XDG_DATA_HOME="/usr/local" 
 
 curl -LsSf https://astral.sh/uv/install.sh | sh
 


### PR DESCRIPTION
The uv error comes from the recent changes to the directory path. This updates the path while also addressing another error that occurs due to missing pkgconfigs with python 3.12

uv error:
```sh
------                                                                                                                                                                                                                    
 > [agnos-base 10/12] RUN /tmp/agnos/openpilot_python_dependencies.sh:                                                                                                                                                    
0.094 installing uv...                                                                                                                                                                                                    
1.202 downloading uv 0.5.1 aarch64-unknown-linux-gnu                                                                                                                                                                      
2.249 no checksums to verify
2.469 installing to /usr/local/../bin
2.472   uv
2.473   uvx
2.473 everything's installed!
2.487 
2.487 To add /usr/local/../bin to your PATH, either restart your shell or run:
2.487 
2.487     source /usr/local/../bin/env (sh, bash, zsh)
2.487     source /usr/local/../bin/env.fish (fish)
2.489 /tmp/agnos/openpilot_python_dependencies.sh: line 9: /usr/local/.cargo/env: No such file or directory
------
Dockerfile.agnos:76
--------------------
  74 |     RUN /tmp/agnos/openpilot_dependencies.sh
  75 |     COPY ./userspace/openpilot_python_dependencies.sh /tmp/agnos/
  76 | >>> RUN /tmp/agnos/openpilot_python_dependencies.sh
  77 |     
  78 |     # Install old Qt 5.12.8, libwayland 1.9.0-1 and deps
--------------------
ERROR: failed to solve: process "/bin/sh -c /tmp/agnos/openpilot_python_dependencies.sh" did not complete successfully: exit code: 1
```

pkgconfig error:
```sh
 => [stage-6 12/72] COPY ./userspace/uv /tmp/agnos/uv                                                                  0.0s
 => ERROR [stage-6 13/72] RUN source /usr/local/venv/bin/activate &&     cd /tmp/agnos/uv &&     export PYOPENCL_CL_P  0.2s
------
 > [stage-6 13/72] RUN source /usr/local/venv/bin/activate &&     cd /tmp/agnos/uv &&     export PYOPENCL_CL_PRETEND_VERSION="2.0" &&     pc="$(python -c "import sysconfig;print(sysconfig.get_config_vars('installed_base')[0])")" &&     pcpath=$pc"/lib/pkgconfig" &&     export PKG_CONFIG_PATH="$pcpath:$PKG_CONFIG_PATH" &&     pypcpath=$pcpath"/python-3.12.pc" &&     sed -i 's|prefix=/install|prefix='$pc'|' $pypcpath &&     pypcpathembed=$pcpath"/python-3.12-embed.pc" &&     sed -i 's|prefix=/install|prefix='$pc'|' $pypcpathembed &&     MAKEFLAGS="-j$(nproc)" UV_NO_CACHE=1 UV_PROJECT_ENVIRONMENT=/usr/local/venv uv sync --frozen --inexact --compile-bytecode:
0.169 sed: can't read /usr/local/uv/python/cpython-3.13.0-linux-aarch64-gnu/lib/pkgconfig/python-3.12.pc: No such file or directory
------
Dockerfile.agnos:132
--------------------
 131 |     COPY ./userspace/uv /tmp/agnos/uv
 132 | >>> RUN source $XDG_DATA_HOME/venv/bin/activate && \
 133 | >>>     cd /tmp/agnos/uv && \
 134 | >>>     export PYOPENCL_CL_PRETEND_VERSION="2.0" && \
 135 | >>>     pc="$(python -c "import sysconfig;print(sysconfig.get_config_vars('installed_base')[0])")" && \
 136 | >>>     pcpath=$pc"/lib/pkgconfig" && \
 137 | >>>     export PKG_CONFIG_PATH="$pcpath:$PKG_CONFIG_PATH" && \
 138 | >>>     pypcpath=$pcpath"/python-3.12.pc" && \
 139 | >>>     sed -i 's|prefix=/install|prefix='$pc'|' $pypcpath && \
 140 | >>>     pypcpathembed=$pcpath"/python-3.12-embed.pc" && \
 141 | >>>     sed -i 's|prefix=/install|prefix='$pc'|' $pypcpathembed && \
 142 | >>>     MAKEFLAGS="-j$(nproc)" UV_NO_CACHE=1 UV_PROJECT_ENVIRONMENT=$XDG_DATA_HOME/venv uv sync --frozen --inexact --compile-bytecode
 143 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c source $XDG_DATA_HOME/venv/bin/activate &&     cd /tmp/agnos/uv &&     export PYOPENCL_CL_PRETEND_VERSION=\"2.0\" &&     pc=\"$(python -c \"import sysconfig;print(sysconfig.get_config_vars('installed_base')[0])\")\" &&     pcpath=$pc\"/lib/pkgconfig\" &&     export PKG_CONFIG_PATH=\"$pcpath:$PKG_CONFIG_PATH\" &&     pypcpath=$pcpath\"/python-3.12.pc\" &&     sed -i 's|prefix=/install|prefix='$pc'|' $pypcpath &&     pypcpathembed=$pcpath\"/python-3.12-embed.pc\" &&     sed -i 's|prefix=/install|prefix='$pc'|' $pypcpathembed &&     MAKEFLAGS=\"-j$(nproc)\" UV_NO_CACHE=1 UV_PROJECT_ENVIRONMENT=$XDG_DATA_HOME/venv uv sync --frozen --inexact --compile-bytecode" did not complete successfully: exit code: 2
```

A similar uv error was addressed in the following PR on openpilot: https://github.com/commaai/openpilot/pull/33975

After applying these changes i was able to successfully run `./build_system.sh`