### PR TITLE
`docs`: improve flashing device section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Building
 ./build_system.sh
 ```
 
-Flashing to a comma 3/3X:
+Flashing to a comma 3/3X (Be sure to set your device in QDL mode before flashing. Refer to [QDL MODE Section](https://flash.comma.ai/) for more information.):
 ```
 ./flash_kernel.sh
 ./flash_system.sh

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Flashing to a comma 3/3X:
 ./flash_system.sh
 ```
 
+> [!NOTE]
+> If flashing on M-series Macs, you may need to run `brew install libusb` and then `sudo mkdir -p /usr/local/lib && sudo ln -s /opt/homebrew/lib/libusb-1.0.0.dylib /usr/local/lib/libusb.dylib` if getting "No backend available".
+
 Validating changes:
 * Running openpilot is a good smoketest for general AGNOS functionality
 * [CI](https://github.com/commaai/agnos-builder/blob/master/.github/workflows/build.yaml) ensures the kernel and system builds work (and pushes the images for you to download)


### PR DESCRIPTION
Was running into issues with `./flash_system.sh` until running into this [Discord message](https://discord.com/channels/469524606043160576/1263672324973138033/1264961677024038923) which led me to finding instructions within `./flash_system.sh`

The error:
```sh
└─(22:53:12 on fix-system-build-errors ✹)──> ./flash_system.sh            
Checking active slot...
Traceback (most recent call last):
  File "/Volumes/agnos/agnos-builder/tools/edl_repo/edl", line 393, in <module>
    base.run()
  File "/Volumes/agnos/agnos-builder/tools/edl_repo/edl", line 290, in run
    conninfo = self.doconnect(loop)
  File "/Volumes/agnos/agnos-builder/tools/edl_repo/edl", line 200, in doconnect
    self.cdc.connected = self.cdc.connect(portname=self.portname)
  File "/Volumes/agnos/agnos-builder/tools/edl_repo/edlclient/Library/Connection/usblib.py", line 221, in connect
    devices = usb.core.find(find_all=True, backend=self.backend)
  File "/Volumes/agnos/agnos-builder/tools/edl_repo/venv/lib/python3.10/site-packages/usb/core.py", line 1309, in find
    raise NoBackendError('No backend available')
usb.core.NoBackendError: No backend available
Invalid active slot: ''
```

it would be nicer to just have it be included in the `README.md` as part of the flash section noting the necessary steps if attempting to flash with M-Series macs

Also mentioned the need to set the device in QDL mode in order to run `./flash_system.sh` with no issues.