### PR TITLE
Use debhelper tools for dependency compilation and packaging

### DIFF
--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -14,6 +14,8 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     clang \
     curl \
     checkinstall \
+    dh-make \
+    dpkg-dev \
     git \
     pkg-config \
     wget


### PR DESCRIPTION
Use debhelper tools for creation of the .deb packages rather than old checkinstall.