### PR TITLE
add GPU temp to tmux info bar

### DIFF
--- a/userspace/home/.tmux.conf
+++ b/userspace/home/.tmux.conf
@@ -9,7 +9,7 @@ set -g status-left ''
 
 set -g status-left-length 20
 set -g history-limit 7200
-set -g status-right '#[fg=colour230,bold] #(cat /data/params/d/DongleId | cut -c 1-16) #[fg=colour233,bg=colour241,bold] %d/%m #[fg=colour233,bg=colour245,bold] %H:%M:%S '
+set -g status-right '#[fg=colour230,bold] #(cat /data/params/d/DongleId | cut -c 1-16) #(echo "scale=1; $(cat /sys/devices/virtual/thermal/thermal_zone11/temp)/1000" | bc)°C#[fg=colour233,bg=colour241,bold] %d/%m #[fg=colour233,bg=colour245,bold] %H:%M:%S '
 set -g status-right-length 70
 setw -g window-status-current-style fg=colour81,bg=colour238,bold
 setw -g window-status-current-format ' #I#[fg=colour250]:#[fg=colour255]#W#[fg=colour50]#F '

--- a/userspace/home/.tmux.conf
+++ b/userspace/home/.tmux.conf
@@ -9,7 +9,7 @@ set -g status-left ''
 
 set -g status-left-length 20
 set -g history-limit 7200
-set -g status-right '#[fg=colour230,bold] #(cat /data/params/d/DongleId | cut -c 1-16) #(echo "scale=1; $(cat /sys/devices/virtual/thermal/thermal_zone11/temp)/1000" | bc)°C#[fg=colour233,bg=colour241,bold] %d/%m #[fg=colour233,bg=colour245,bold] %H:%M:%S '
+set -g status-right '#[fg=colour230,bold]#(cat /data/params/d/DongleId | cut -c 1-16) #[fg=colour233,bg=colour239,bold] #(echo "scale=1; $(cat /sys/devices/virtual/thermal/thermal_zone11/temp)/1000" | bc)°C #[fg=colour233,bg=colour241,bold] %d/%m #[fg=colour233,bg=colour245,bold] %H:%M:%S '
 set -g status-right-length 70
 setw -g window-status-current-style fg=colour81,bg=colour238,bold
 setw -g window-status-current-format ' #I#[fg=colour250]:#[fg=colour255]#W#[fg=colour50]#F '


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1a3ce773-b24c-4920-9167-e263cf39a2bb)

dividing by 1000 is necessary since in unix systems the temperature is given to us in millidegrees (Celsius)

https://developer.toradex.com/software/linux-resources/linux-features/temperature-sensor-linux/?t#nxpfreescale-imx-6-based-modules

seemed helpful to include since it was mentioned in this issue https://github.com/commaai/agnos-builder/issues/405