### PR TITLE
Remove redundant comma service parameters

### DIFF
--- a/userspace/files/comma.service
+++ b/userspace/files/comma.service
@@ -7,8 +7,6 @@ User=comma
 Restart=always
 ExecStart=/bin/bash -c "/usr/bin/tmux new-session -s comma -d /usr/comma/comma.sh && sleep infinity"
 TimeoutStopSec=1
-KillSignal=SIGTERM
-RestartKillSignal=SIGKILL
 LimitRTPRIO=100
 LimitNICE=-10
 


### PR DESCRIPTION
Follow up to https://github.com/commaai/agnos-builder/pull/228, not sure why I misunderstood the parameters. Re-reading https://www.freedesktop.org/software/systemd/man/latest/systemd.kill.html and https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html makes it clear that only the delay is required