### PR TITLE
`docs`: replace QDL with EDL instructions + `./flash_all.sh` mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ Building
 ./build_system.sh
 ```
 
-Flashing to a comma 3/3X (Be sure to set your device in QDL mode before flashing. Refer to [QDL MODE Section](https://flash.comma.ai/) for more information.):
+Flashing to a comma 3/3X (Be sure to set your device in EDL mode before flashing. This involves connecting your USB-C cable from your computer to [port 2](https://flash.comma.ai/assets/fastboot-ports-DhWKM-vn.svg)):
 ```
 ./flash_kernel.sh
 ./flash_system.sh
+
+./flash_all.sh <- this runs both scripts one after the other
 ```
 
 > [!NOTE]


### PR DESCRIPTION
adding these to the README.md would save a lot of time for future contributors. The EDL instructions were found through discord searching. [The discord thread that started my discovery](https://discord.com/channels/469524606043160576/1262118077017882715/1331675375289241635)