### PR TITLE
fix noisy `push-and-comment` workflow

### DIFF
--- a/.github/workflows/push-and-comment.yaml
+++ b/.github/workflows/push-and-comment.yaml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success'
+      github.event.workflow_run.conclusion == 'success' &&
+      contains(env.LAST_COMMIT_MESSAGE, '[upload]')
     timeout-minutes: 5
     permissions:
       contents: read


### PR DESCRIPTION
noticed the constant emails that I would receive when pushing to my PRs. Did some investigating and found that it was due to `push-and-comment` attempting to download artifacts from `build.yaml`. However we only expect an artifact when the commit message contains `[upload]`

This added check will prevent the job from running if it does not contain `[upload]`