### PR TITLE
Unblock weston on networking

### DIFF
--- a/userspace/files/weston.service
+++ b/userspace/files/weston.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Weston
 Conflicts=getty@tty1.service
-After=systemd-user-sessions.service getty@tty1.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
4s boot time savings, solves #445

---

Before:
```
comma@comma-5e2e507b:/$ systemd-analyze critical-chain weston.service
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

weston.service +368ms
└─systemd-user-sessions.service @8.381s +37ms
  └─network.target @8.355s
    └─NetworkManager.service @4.766s +3.588s
      └─dbus.service @4.520s +206ms
        └─basic.target @4.494s
          └─sockets.target @4.494s
            └─lxd-installer.socket @4.472s +21ms
              └─sysinit.target @4.452s
                └─systemd-resolved.service @4.050s +401ms
                  └─systemd-tmpfiles-setup.service @3.952s +93ms
                    └─local-fs.target @3.944s
                      └─config.mount @8.457s
                        └─local-fs-pre.target @876ms
                          └─keyboard-setup.service @622ms +254ms
                            └─systemd-journald.socket @598ms
                              └─system.slice @404ms
                                └─-.slice @404ms
```

---

After
```
weston.service +551ms
└─basic.target @3.874s
  └─sockets.target @3.874s
    └─lxd-installer.socket @3.858s +15ms
      └─sysinit.target @3.846s
        └─systemd-resolved.service @3.568s +277ms
          └─systemd-tmpfiles-setup.service @3.458s +103ms
            └─local-fs.target @3.437s
              └─config.mount @7.724s
                └─local-fs-pre.target @667ms
                  └─keyboard-setup.service @463ms +203ms
                    └─systemd-journald.socket @445ms
                      └─system.slice @195ms
                        └─-.slice @195ms
```