### PR TITLE
Use tonistiigi/binfmt for emulation to fix qemu segfaults

### DIFF
--- a/build_system.sh
+++ b/build_system.sh
@@ -40,8 +40,8 @@ fi
 
 # Setup qemu multiarch
 if [ "$(uname -m)" = "x86_64" ]; then
-  echo "Registering qemu-user-static"
-  docker run --rm --privileged multiarch/qemu-user-static --reset -p yes > /dev/null
+  echo "Registering emulator"
+  docker run --rm --privileged tonistiigi/binfmt --install all
 fi
 
 # Check agnos-builder Dockerfile


### PR DESCRIPTION
We are currently using the hosts qemu support, which will vary between host os versions. For certain versions of Ubuntu (e.g. 22.04) qemu is currently broken, leading to random segfaults in the docker build. See https://github.com/tonistiigi/binfmt/issues/215 for details.

So instead of relying on the hosts emulation support, use the tonistiigi/binfmt docker image, which works for all hosts.