### PR TITLE
feat: support starting openpilot in an X virtual server

### DIFF
--- a/userspace/openpilot_dependencies.sh
+++ b/userspace/openpilot_dependencies.sh
@@ -45,9 +45,17 @@ apt-fast install --no-install-recommends -yq \
     libva-dev \
     libvdpau-dev \
     libvorbis-dev \
+    libxcb-icccm4 \
+    libxcb-image0 \
+    libxcb-keysyms1 \
+    libxcb-render-util0 \
     libxcb-shm0-dev \
     libxcb-xfixes0-dev \
+    libxcb-xinerama0 \
+    libxcb-xinput0 \
+    libxcb-xkb1 \
     libxcb1-dev \
+    libxkbcommon-x11-0 \
     libzmq3-dev \
     libzstd-dev \
     locales \
@@ -60,5 +68,6 @@ apt-fast install --no-install-recommends -yq \
     texinfo \
     vnstat \
     wget \
+    xvfb \
     zlib1g-dev \
     zstd


### PR DESCRIPTION
the Qt X backend does not start up due to missing dependencies:
```
QT_DEBUG_PLUGINS=1 QT_QPA_PLATFORM=xcb selfdrive/ui/ui
...
: QLibraryPrivate::loadPlugin failed on "/usr/lib/aarch64-linux-gnu/qt5/plugins/platforms/libqxcb.so" : "Cannot load library /usr/lib/aarch64-linux-gnu/qt5/plugins/platforms/libqxcb.so: (libxcb-xinput.so.0: cannot open shared object file: No such file or directory)"
: This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```

so, adding missing shared objects for x backend:
```
comma@comma-bb546e42:/data/openpilot$ ldd /usr/lib/aarch64-linux-gnu/qt5/plugins/platforms/libqxcb.so  | grep 'not found'
        libxcb-xinput.so.0 => not found
        libxcb-icccm.so.4 => not found
        libxcb-image.so.0 => not found
        libxcb-keysyms.so.1 => not found
        libxcb-render-util.so.0 => not found
        libxcb-xinerama.so.0 => not found
        libxcb-xkb.so.1 => not found
        libxkbcommon-x11.so.0 => not found
```

adding `xvfb` as well so we can start virtual X displays.