### PR TITLE
sync_openpilot_dependencies.sh improvements

### DIFF
--- a/sync_openpilot_dependencies.sh
+++ b/sync_openpilot_dependencies.sh
@@ -5,6 +5,11 @@ set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 cd $DIR
 
+if ! command -v "uv" > /dev/null 2>&1; then
+  echo "installing uv..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+
 cd userspace/uv
 curl -sSo openpilot/pyproject.toml https://raw.githubusercontent.com/commaai/openpilot/master/pyproject.toml
 

--- a/sync_openpilot_dependencies.sh
+++ b/sync_openpilot_dependencies.sh
@@ -9,7 +9,7 @@ cd userspace/uv
 curl -sSo openpilot/pyproject.toml https://raw.githubusercontent.com/commaai/openpilot/master/pyproject.toml
 
 export PYOPENCL_CL_PRETEND_VERSION="2.0" && \
-pc="$(python -c "import sysconfig;print(sysconfig.get_config_vars('installed_base')[0])")" && \
+pc="$(python3 -c "import sysconfig;print(sysconfig.get_config_vars('installed_base')[0])")" && \
 pcpath=$pc"/lib/pkgconfig" && \
 export PKG_CONFIG_PATH="$pcpath:$PKG_CONFIG_PATH" && \
 uv lock --upgrade


### PR DESCRIPTION
- use `python3` instead of `python`
- install `uv` if it's not installed