### PR TITLE
feat: build ffmpeg with libx264 support

### DIFF
--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -190,6 +190,7 @@ apt-fast install --no-install-recommends -yq \
     libgles1 \
     libgles2 \
     libgles-dev \
+    libx264-dev \
     openssh-server \
     dnsmasq-base \
     isc-dhcp-client \

--- a/userspace/compile-ffmpeg.sh
+++ b/userspace/compile-ffmpeg.sh
@@ -13,6 +13,7 @@ apt-get update && apt-get install -yq --no-install-recommends \
     libva-dev \
     libvdpau-dev \
     libvorbis-dev \
+    libx264-dev \
     libxcb1-dev \
     libxcb-shm0-dev \
     libxcb-xfixes0-dev \
@@ -32,7 +33,7 @@ cd ffmpeg-${VERSION}
 # --disable-doc works too, disables building documentation completely
 # https://gist.github.com/omegdadi/6904512c0a948225c81114b1c5acb875
 # https://github.com/7Ji/archrepo/issues/10
-./configure --enable-shared --disable-static --disable-htmlpages
+./configure --enable-gpl --enable-libx264 --enable-shared --disable-static --disable-htmlpages
 make -j$(nproc)
 
 # remove "--fstrans=no" when checkinstall is fixed (still not fixed in 24.04)


### PR DESCRIPTION
required for running clips on device

other blockers are still there (like replay, selfdrive/ui, ffmpeg optimizations), but we at least need ffmpeg to support x264 encoding

getting in now since new AGNOS release is very soon: https://github.com/commaai/agnos-builder/pull/472#issuecomment-2889267793

```bash
./build_system.sh
./flash_system.sh
```

```bash
comma@comma-bb546e42:/data/openpilot$ ffmpeg
ffmpeg version 4.2.2 Copyright (c) 2000-2019 the FFmpeg developers
  built with gcc 13 (Ubuntu 13.3.0-6ubuntu2~24.04)
  configuration: --enable-gpl --enable-libx264 --enable-shared --disable-static --disable-htmlpages
  libavutil      56. 31.100 / 56. 31.100
  libavcodec     58. 54.100 / 58. 54.100
  libavformat    58. 29.100 / 58. 29.100
  libavdevice    58.  8.100 / 58.  8.100
  libavfilter     7. 57.100 /  7. 57.100
  libswscale      5.  5.100 /  5.  5.100
  libswresample   3.  5.100 /  3.  5.100
  libpostproc    55.  5.100 / 55.  5.100
Hyper fast Audio and Video encoder
usage: ffmpeg [options] [[infile options] -i infile]... {[outfile options] outfile}...

Use -h to get full help or, even better, run 'man ffmpeg'
```