### PR TITLE
fix libs and libs32 symlinks in docker

### DIFF
--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -186,8 +186,8 @@ RUN touch -r /lib/systemd/systemd /etc/fstab
 # populate /usr
 COPY ./userspace/usr/comma/ /usr/$USERNAME/
 COPY ./userspace/usr/share/fonts/* /usr/share/fonts/
-COPY ./userspace/libs/* /usr/lib/aarch64-linux-gnu/
-COPY ./userspace/libs32/* /usr/lib/arm-linux-gnueabihf/
+COPY ./userspace/libs /usr/lib/aarch64-linux-gnu/
+COPY ./userspace/libs32 /usr/lib/arm-linux-gnueabihf/
 
 # this is big, only enable when we need it
 # kernel headers for the AGNOS kernel (built on device)


### PR DESCRIPTION
Before:
```
$ tree userspace/libs
|-- libbase.so.0
|-- libbase.so.0.0.0
...
```

After:
```
$ tree userspace/libs
|-- libbase.so.0 -> libbase.so.0.0.0
|-- libbase.so.0.0.0
...
```