### PR TITLE
Fix kernel build ccache not being used in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,13 +41,19 @@ jobs:
       id: kernel-submodule
       run: echo "ref=$(git ls-tree HEAD | awk '$4 == "agnos-kernel-sdm845"' | awk '{print $3}')" | tee -a $GITHUB_OUTPUT
 
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@c92f40bee50034e84c763e33b317c77adaa81c92
+    - name: Restore ccache
+      uses: actions/cache@v4
       with:
-        key: kernel-${{ steps.kernel-submodule.outputs.ref }}
-        restore-keys: kernel-
+        path: .ccache
+        key: ccache-kernel-${{ steps.kernel-submodule.outputs.ref }}-${{ github.run_id }}
+        restore-keys: |
+          ccache-kernel-${{ steps.kernel-submodule.outputs.ref }}-
+          ccache-kernel-
 
     - name: Build kernel
+      env:
+        CCACHE_DIR: ${{ github.workspace }}/.ccache
+        CCACHE_MAXSIZE: 5G
       run: ./build_kernel.sh
 
     - name: Update VERSION

--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -61,6 +61,11 @@ build_kernel() {
   # Set ccache dir
   export CCACHE_DIR=$DIR/.ccache
 
+  # Force ccache usage for kernel build (both target and host compilers)
+  export PATH="/usr/lib/ccache:$PATH"
+  export HOSTCC="ccache gcc"
+  export HOSTCXX="ccache g++"
+
   # Avoid LINUX_COMPILE_HOST to change on every run thus invalidating cache
   # https://patchwork.kernel.org/project/linux-kbuild/patch/1302015561-21047-8-git-send-email-mmarek@suse.cz/
   export KBUILD_BUILD_HOST="docker"


### PR DESCRIPTION
## Results
| Build | Time |
|-------|------|
| No cache | ~7.5 min |
| With ccache (kernel only) | ~2.5 min |
| **With ccache (kernel + host tools)** | **~27 sec** |