### PR TITLE
feat(modem): keep ttyUSB2 unbound from modem-manager

### DIFF
--- a/userspace/files/78-modem.rules
+++ b/userspace/files/78-modem.rules
@@ -1,5 +1,6 @@
 # EG25 GNSS
 KERNEL=="ttyUSB0",ATTRS{idVendor}=="2c7c",ATTRS{idProduct}=="0125",ENV{ID_MM_DEVICE_IGNORE}="1"
+KERNEL=="ttyUSB2",ATTRS{idVendor}=="2c7c",ATTRS{idProduct}=="0125",ENV{ID_MM_PORT_IGNORE}="1"
 
 # EG91
 # ttyUSB0 - debug
@@ -8,7 +9,7 @@ KERNEL=="ttyUSB0",ATTRS{idVendor}=="2c7c",ATTRS{idProduct}=="0125",ENV{ID_MM_DEV
 # ttyUSB3 - AT
 KERNEL=="ttyUSB0",ATTRS{idVendor}=="2c7c",ATTRS{idProduct}=="6007",ENV{ID_MM_DEVICE_IGNORE}="1"
 KERNEL=="ttyUSB1",ATTRS{idVendor}=="2c7c",ATTRS{idProduct}=="6007",ENV{ID_MM_DEVICE_IGNORE}="1"
-KERNEL=="ttyUSB2",ATTRS{idVendor}=="2c7c",ATTRS{idProduct}=="6007",ENV{ID_MM_PORT_TYPE_AT_PPP}="1"
+KERNEL=="ttyUSB2",ATTRS{idVendor}=="2c7c",ATTRS{idProduct}=="6007",ENV{ID_MM_PORT_IGNORE}="1"
 KERNEL=="ttyUSB3",ATTRS{idVendor}=="2c7c",ATTRS{idProduct}=="6007",ENV{ID_MM_PORT_TYPE_AT_PRIMARY}="1"
 ACTION=="add",SUBSYSTEM=="usb",ATTR{idVendor}=="2c7c",ATTR{idProduct}=="6007",RUN+="/bin/sh -c 'echo -n $kernel:1.4 > /sys/bus/usb/drivers/cdc_ether/unbind'"
 


### PR DESCRIPTION
allows one of the two AT ports on the EGXX modems to be unused by `ModemManager`, allowing eSIM read/write operations without forcing `ModemManager` offline

EG25 for three/x and EG9X for four

~i'm unsure of the implications of having `ModemManager` only use the 1 port and what the intention of keeping one AT port "to be used as data ports exclusively." -- hoping for input from the engineering team on this!~

safe, see https://github.com/commaai/agnos-builder/pull/521#issuecomment-3935675338

https://www.freedesktop.org/software/ModemManager/doc/1.20.0/ModemManager/ModemManager-Common-udev-tags.html#ID-MM-PORT-TYPE-AT-PPP:CAPS

tested on:
- 3x
- four