### PR TITLE
remove gcc-arm-none-eabi

### DIFF
--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -237,14 +237,6 @@ COPY ./userspace/files/CAMERA_ICP.elf /usr/lib/firmware
 # Setup hostname resolution for our custom hostname
 RUN sed -i 's/hosts:          files dns myhostname/hosts:          files myhostname dns/g' /etc/nsswitch.conf
 
-# TODO: move this to base_setup.sh or build gcc from source
-# Remove unused architectures & bins from arm-none-eabi
-RUN cd /usr/lib/gcc/arm-none-eabi/* && \
-    rm -rf arm/ && \
-    find thumb/ -maxdepth 1 -type d ! \( -name 'thumb' -o -name 'v7e-m+fp' -o -name 'v7e-m+dp' \) -exec rm -rf {} + && \
-    rm cc1plus g++-mapper-server && \
-    find /usr/bin -maxdepth 1 -type f -name 'arm-none-eabi-*' ! \( -name 'arm-none-eabi-gcc' -o -name 'arm-none-eabi-objcopy' -o -name 'arm-none-eabi-objdump' \) -delete
-
 # keep this last
 RUN ldconfig
 

--- a/userspace/openpilot_dependencies.sh
+++ b/userspace/openpilot_dependencies.sh
@@ -17,7 +17,6 @@ apt-fast install --no-install-recommends -yq \
     curl \
     darkstat \
     dkms \
-    gcc-arm-none-eabi \
     gettext \
     gpiod \
     libarchive-dev \


### PR DESCRIPTION
It's getting vendored in the panda repo instead https://github.com/commaai/panda/pull/2342