### PR TITLE
Faster time syncing when no internet

### DIFF
--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -212,7 +212,7 @@ RUN echo "precedence ::ffff:0:0/96 100" >> /etc/gai.conf
 # Don't let logind delete /dev/shm
 COPY ./userspace/files/logind.conf /etc/systemd/logind.conf
 
-# Retry NTP sync every 5s instead of 30s for faster time sync after network connects
+# Retry NTP sync every 10s instead of 30s for faster time sync after network connects
 COPY ./userspace/files/timesyncd.conf /etc/systemd/timesyncd.conf
 
 # Copy Avahi daemon override

--- a/userspace/files/timesyncd.conf
+++ b/userspace/files/timesyncd.conf
@@ -1,2 +1,3 @@
 [Time]
-ConnectionRetrySec=5
+# 10s is limited by timesyncd rate limit
+ConnectionRetrySec=10


### PR DESCRIPTION
This is to remove 15s mean, 30s max delay from setup where it shows connected + waiting for internet. I was mostly worried about unnecessary network requests when user turns on device with no internet with this change, however it looks like we only hit the internal DNS cache (`systemd-resolved`) and stop there. See below.

`time getent hosts ntp.ubuntu.com` while connected to internet:

goes to internal dns resolver/cacher (systemd-resolved), then out to the ntp server

```
sudo tcpdump -i any port 53
05:25:20.049405 lo    In  IP localhost.localdomain.34437 > _localdnsstub.domain: 28682+ [1au] A? ntp.ubuntu.com. (43)
05:25:20.049492 lo    In  IP localhost.localdomain.34437 > _localdnsstub.domain: 8988+ [1au] AAAA? ntp.ubuntu.com. (43)
05:25:20.050935 wlan0 Out IP comma-8c64008d.38821 > _gateway.domain: 46134+ [1au] A? ntp.ubuntu.com. (43)
05:25:20.051534 lo    In  IP _localdnsstub.domain > localhost.localdomain.34437: 8988 3/0/1 AAAA 2620:2d:4000:1::40, AAAA 2620:2d:4000:1::41, AAAA 2620:2d:4000:1::3f (127)
05:25:20.072821 wlan0 In  IP _gateway.domain > comma-8c64008d.38821: 46134 4/0/1 A 185.125.190.57, A 91.189.91.157, A 185.125.190.56, A 185.125.190.58 (107)
05:25:20.073641 lo    In  IP _localdnsstub.domain > localhost.localdomain.34437: 28682 4/0/1 A 185.125.190.57, A 91.189.91.157, A 185.125.190.56, A 185.125.190.58 (107)
05:25:20.077261 lo    In  IP localhost.localdomain.59006 > _localdnsstub.domain: 63666+ [1au] AAAA? ntp.ubuntu.com. (43)
05:25:20.077849 lo    In  IP _localdnsstub.domain > localhost.localdomain.59006: 63666 3/0/1 AAAA 2620:2d:4000:1::41, AAAA 2620:2d:4000:1::40, AAAA 2620:2d:4000:1::3f (127)
```

disconnected from internet:

never hits wlan0

```
sudo tcpdump -i any port 53
05:25:59.634568 lo    In  IP localhost.localdomain.38363 > _localdnsstub.domain: 33483+ [1au] AAAA? ntp.ubuntu.com. (43)
05:25:59.635035 lo    In  IP _localdnsstub.domain > localhost.localdomain.38363: 33483 ServFail* 0/0/1 (43)
05:25:59.635374 lo    In  IP localhost.localdomain.40833 > _localdnsstub.domain: 33483+ [1au] AAAA? ntp.ubuntu.com. (43)
05:25:59.635654 lo    In  IP _localdnsstub.domain > localhost.localdomain.40833: 33483 ServFail* 0/0/1 (43)
05:25:59.635930 lo    In  IP localhost.localdomain.54450 > _localdnsstub.domain: 52100+ [1au] AAAA? ntp.ubuntu.com. (43)
05:25:59.636185 lo    In  IP _localdnsstub.domain > localhost.localdomain.54450: 52100 ServFail* 0/0/1 (43)
05:25:59.636442 lo    In  IP localhost.localdomain.57176 > _localdnsstub.domain: 52100+ [1au] AAAA? ntp.ubuntu.com. (43)
05:25:59.636692 lo    In  IP _localdnsstub.domain > localhost.localdomain.57176: 52100 ServFail* 0/0/1 (43)
05:25:59.637059 lo    In  IP localhost.localdomain.35629 > _localdnsstub.domain: 55504+ [1au] A? ntp.ubuntu.com. (43)
05:25:59.637300 lo    In  IP _localdnsstub.domain > localhost.localdomain.35629: 55504 ServFail* 0/0/1 (43)
05:25:59.637554 lo    In  IP localhost.localdomain.41447 > _localdnsstub.domain: 55504+ [1au] A? ntp.ubuntu.com. (43)
05:25:59.637800 lo    In  IP _localdnsstub.domain > localhost.localdomain.41447: 55504 ServFail* 0/0/1 (43)
05:25:59.638054 lo    In  IP localhost.localdomain.40991 > _localdnsstub.domain: 57215+ [1au] A? ntp.ubuntu.com. (43)
05:25:59.638370 lo    In  IP _localdnsstub.domain > localhost.localdomain.40991: 57215 ServFail* 0/0/1 (43)
05:25:59.638665 lo    In  IP localhost.localdomain.39531 > _localdnsstub.domain: 57215+ [1au] A? ntp.ubuntu.com. (43)
05:25:59.638899 lo    In  IP _localdnsstub.domain > localhost.localdomain.39531: 57215 ServFail* 0/0/1 (43)
05:25:59.700953 lo    In  IP localhost.localdomain.40449 > _localdnsstub.domain: 60909+ [1au] PTR? 53.0.0.127.in-addr.arpa. (52)
05:25:59.701544 lo    In  IP _localdnsstub.domain > localhost.localdomain.40449: 60909*$ 1/0/1 PTR _localdnsstub. (79)
```

---

Something to note, when `timed` sets the time from the GPS, `systemd-timesyncd` notices the jump and does its own resync which only is successful if internet, otherwise it tries every 5s until internet: https://github.com/systemd/systemd/blob/fbf533859f312de19e25979ebf243d6929c00d1d/src/timesync/timesyncd-manager.c#L206-L223