### PR TITLE
set_adb: enable ADB when userdata is not mounted

### DIFF
--- a/userspace/usr/comma/set_adb.sh
+++ b/userspace/usr/comma/set_adb.sh
@@ -57,7 +57,7 @@ stop() {
 }
 
 ADB_PARAM="/data/params/d/AdbEnabled"
-if [ -f "$ADB_PARAM" ] && [ "$(< $ADB_PARAM)" == "1" ]; then
+if ! mountpoint -q /data || ([ -f "$ADB_PARAM" ] && [ "$(< $ADB_PARAM)" == "1" ]); then
   echo "Enabling ADB"
 
   setup


### PR DESCRIPTION
When userdata is corrupt or unmounted, ADB should still be available for debugging.

Closes https://github.com/commaai/agnos-builder/issues/534