### PR TITLE
fix corrupted slot B type GUIDs in LUN 4 GPT

### DIFF
--- a/firmware/gpt_main_4.img
+++ b/firmware/gpt_main_4.img
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e9405dcd785dbe79412184e1894a9c51ab7deb33bb612166c4c42a3d2bf42a0e
+oid sha256:badb3b81da0999d119d25c88f4eb652f8771a496f267b0564df4847301b01172
 size 24576


### PR DESCRIPTION
## Summary
- All slot B partition type GUIDs on LUN 4 were set to `77036cd4-03d5-42bb-8ed1-37e5a88baa34` instead of their correct per-partition type GUIDs
- This caused the bootloader to fail with `ValidateSlotGuids: BootableSlot _b does not have valid guids` / `FindBootableSlot() status: Device Error`
- Fixed by copying each slot A partition's type GUID to its corresponding slot B entry (aop_a→aop_b, tz_a→tz_b, boot_a→boot_b, etc.) and recalculating GPT CRCs

## Test plan
- [x] Flashed fixed GPT via `tools/qdl repairgpt 4 firmware/gpt_main_4.img`
- [x] Verified slot B type GUIDs match slot A via `tools/qdl printgpt`
- [x] Device boots successfully on slot B