### PR TITLE
rm namespace

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build:
     name: build kernel and system
-    runs-on: namespace-profile-arm64-8x16-2004-caching
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Switched from namespace to GitHub arm64 runner `ubuntu-24.04-arm`:
- kernel build 3m
- system image 18m
- total 23m 29s