### PR TITLE
userspace: teach sound init about the simple audio card

### DIFF
--- a/userspace/usr/comma/sound/sound_init.sh
+++ b/userspace/usr/comma/sound/sound_init.sh
@@ -3,21 +3,45 @@
 /usr/comma/sound/adsp-start.sh
 
 echo "waiting for sound card to come online"
-while [ ! -d /proc/asound/sdm845tavilsndc ] || [ "$(cat /proc/asound/card0/state 2> /dev/null)" != "ONLINE" ] ; do
+while [ ! -f /proc/asound/card0/state ] || [ "$(cat /proc/asound/card0/state 2> /dev/null)" != "ONLINE" ] ; do
   sleep 0.01
 done
 echo "sound card online"
 
-while ! /usr/comma/sound/tinymix controls | grep -q "SEC_MI2S_RX Audio Mixer MultiMedia1"; do
+find_control() {
+  local control
+
+  for control in "$@"; do
+    if /usr/comma/sound/tinymix controls | grep -F -q "$control"; then
+      echo "$control"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+if grep -q mici /sys/firmware/devicetree/base/model; then
+  CAPTURE_CANDIDATES=("Comma Audio Mixer SEC_MI2S_TX" "MultiMedia1 Mixer SEC_MI2S_TX")
+else
+  CAPTURE_CANDIDATES=("Comma Audio Mixer TERT_MI2S_TX" "MultiMedia1 Mixer TERT_MI2S_TX")
+fi
+
+PLAYBACK_CANDIDATES=("SEC_MI2S_RX Audio Mixer Comma Audio" "SEC_MI2S_RX Audio Mixer MultiMedia1")
+
+while true; do
+  PLAYBACK_CONTROL=$(find_control "${PLAYBACK_CANDIDATES[@]}")
+  CAPTURE_CONTROL=$(find_control "${CAPTURE_CANDIDATES[@]}")
+  if [ -n "$PLAYBACK_CONTROL" ] && [ -n "$CAPTURE_CONTROL" ]; then
+    break
+  fi
   sleep 0.01
 done
 echo "tinymix controls ready"
 
-/usr/comma/sound/tinymix set "SEC_MI2S_RX Audio Mixer MultiMedia1" 1
-if grep -q mici /sys/firmware/devicetree/base/model; then
-  /usr/comma/sound/tinymix set "MultiMedia1 Mixer SEC_MI2S_TX" 1
-else
-  /usr/comma/sound/tinymix set "MultiMedia1 Mixer TERT_MI2S_TX" 1
+/usr/comma/sound/tinymix set "$PLAYBACK_CONTROL" 1
+/usr/comma/sound/tinymix set "$CAPTURE_CONTROL" 1
+if /usr/comma/sound/tinymix controls | grep -F -q "TERT_MI2S_TX Channels"; then
   /usr/comma/sound/tinymix set "TERT_MI2S_TX Channels" Two
 fi
 


### PR DESCRIPTION
## Summary
Teach AGNOS sound initialization about the new simple comma audio card while keeping the legacy control names as fallbacks.

## What changes
- stop keying sound-card readiness off the legacy `/proc/asound/sdm845tavilsndc` path
- look for the new fixed-route mixer controls first and fall back to the existing `MultiMedia1` controls
- keep the tertiary MI2S channel count programming that the current capture path still relies on

## Notes
This is intended to pair with commaai/agnos-kernel-sdm845#107. It remains backward-compatible with the current card naming so it can land ahead of or alongside the kernel change.
