### PR TITLE
Provisions to speed up system build time

### DIFF
--- a/build_system.sh
+++ b/build_system.sh
@@ -48,28 +48,36 @@ fi
 export DOCKER_BUILDKIT=1
 docker buildx build -f Dockerfile.agnos --check $DIR
 
-# Start build and create container
-echo "Building agnos-builder docker image"
-BUILD="docker buildx build --load"
-if [ ! -z "$NS" ]; then
-  BUILD="nsc build --load"
-fi
-$BUILD -f Dockerfile.agnos -t agnos-builder $DIR --build-arg UBUNTU_BASE_IMAGE=$UBUNTU_FILE --platform=linux/arm64
-echo "Creating agnos-builder container"
-CONTAINER_ID=$(docker container create --entrypoint /bin/bash agnos-builder:latest)
-
 # Check agnos-meta-builder Dockerfile
 docker buildx build --load -f Dockerfile.builder --check $DIR \
   --build-arg UNAME=$(id -nu) \
   --build-arg UID=$(id -u) \
   --build-arg GID=$(id -g)
 
+# Start build and create container
+echo "Building agnos-builder docker image"
+BUILD="docker buildx build --load"
+if [ ! -z "$NS" ]; then
+  BUILD="nsc build --load"
+fi
+$BUILD -f Dockerfile.agnos -t agnos-builder $DIR --build-arg UBUNTU_BASE_IMAGE=$UBUNTU_FILE --platform=linux/arm64 &
+PID_AGNOS=$!
+
 # Setup mount container for macOS and CI support (namespace.so)
 echo "Building agnos-meta-builder docker image"
 docker buildx build --load -f Dockerfile.builder -t agnos-meta-builder $DIR \
   --build-arg UNAME=$(id -nu) \
   --build-arg UID=$(id -u) \
-  --build-arg GID=$(id -g)
+  --build-arg GID=$(id -g) &
+PID_META_BUILDER=$!
+
+# wait for both image builds to finish
+wait $PID_AGNOS
+wait $PID_META_BUILDER
+
+echo "Creating agnos-builder container"
+CONTAINER_ID=$(docker container create --entrypoint /bin/bash agnos-builder:latest)
+
 echo "Starting agnos-meta-builder container"
 MOUNT_CONTAINER_ID=$(docker run -d --privileged -v $DIR:$DIR agnos-meta-builder)
 

--- a/build_system.sh
+++ b/build_system.sh
@@ -41,7 +41,7 @@ fi
 # Setup qemu multiarch
 if [ "$(uname -m)" = "x86_64" ]; then
   echo "Registering emulator"
-  docker run --rm --privileged tonistiigi/binfmt --install all
+  docker run --rm --privileged tonistiigi/binfmt --install arm64
 fi
 
 # Check agnos-builder Dockerfile
@@ -56,11 +56,13 @@ docker buildx build --load -f Dockerfile.builder --check $DIR \
 
 # Start build and create container
 echo "Building agnos-builder docker image"
-BUILD="docker buildx build --load"
+BUILD="docker buildx build --load --platform=linux/arm64"
 if [ ! -z "$NS" ]; then
-  BUILD="nsc build --load"
+  BUILD="nsc build --load --platform=linux/arm64"
+elif [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then
+  BUILD="docker build"
 fi
-$BUILD -f Dockerfile.agnos -t agnos-builder $DIR --build-arg UBUNTU_BASE_IMAGE=$UBUNTU_FILE --platform=linux/arm64 &
+$BUILD -f Dockerfile.agnos -t agnos-builder $DIR --build-arg UBUNTU_BASE_IMAGE=$UBUNTU_FILE &
 PID_AGNOS=$!
 
 # Setup mount container for macOS and CI support (namespace.so)


### PR DESCRIPTION
This PR includes the following changes:
1. Parallelize image builds
    - Build agnos-builder and agnos-meta-builder concurrently, then wait for both before container creation.
2. Tighten architecture handling for faster/cleaner builds
    - Limit binfmt registration from all to arm64 on x86_64 hosts.
    - Use native docker build on arm64/aarch64 hosts, and keep buildx/nsc pinned to --platform=linux/arm64 where cross-build is needed.

Addresses #259