### PR TITLE
Update modem fimware

### DIFF
--- a/firmware/modem.img
+++ b/firmware/modem.img
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a3d014f0896d77a2df7e5a80a70f43a51a047b9d03cfc675b6f0e31a6ecc4994
+oid sha256:115802fedc39db6f5060a8f21dd3647b789d39a262b8c40f8871875b680d16bf
 size 125829120


### PR DESCRIPTION
modem fw updated from 00459 -> 00956, potentially fixing use after free bug (commaai/openpilot#35788).

still validating, but looking good so far