### PR TITLE
Speed up "Build system" CI step from ~10min to <5min

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint-dockerfiles:
+    name: lint Dockerfiles
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@v4
+    - name: Check Dockerfile.agnos
+      run: docker buildx build -f Dockerfile.agnos --check .
+    - name: Check Dockerfile.builder
+      run: |
+        docker buildx build -f Dockerfile.builder --check . \
+          --build-arg UNAME=$(id -nu) \
+          --build-arg UID=$(id -u) \
+          --build-arg GID=$(id -g)
+
   build:
     name: build kernel and system
     runs-on: ubuntu-24.04-arm

--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -49,6 +49,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     libgirepository1.0-dev \
     libglib2.0-dev \
     libgudev-1.0-dev \
+    libmbim-glib-dev \
     libpolkit-gobject-1-dev \
     libqmi-glib-dev \
     libsystemd-dev \

--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -27,6 +27,10 @@ EOF
 
 # Common packages + union of libqmi and ModemManager build deps so each
 # compile stage doesn't re-run apt update/install.
+# libqmi-glib-dev (Ubuntu's 1.34) is included so the ModemManager stage
+# can compile in parallel with our libqmi-from-source (1.36) build —
+# libqmi-glib SONAME=5 is ABI-stable across these versions, and the final
+# image installs the locally-built 1.36 .deb for runtime.
 RUN apt-get update && apt-get install -yq --no-install-recommends \
     bash-completion \
     build-essential \
@@ -46,6 +50,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     libglib2.0-dev \
     libgudev-1.0-dev \
     libpolkit-gobject-1-dev \
+    libqmi-glib-dev \
     libsystemd-dev \
     meson \
     ninja-build \
@@ -65,8 +70,11 @@ COPY ./userspace/compile-libqmi.sh /tmp/agnos/
 RUN --mount=type=cache,target=/root/.ccache,id=libqmi,sharing=shared \
     /tmp/agnos/compile-libqmi.sh
 
-# ModemManager
-FROM agnos-compiler-libqmi AS agnos-compiler-modemmanager
+# ModemManager — runs in parallel with libqmi under buildkit, since this
+# stage no longer FROMs the libqmi stage. MM compiles against the libqmi
+# headers from Ubuntu's libqmi-glib-dev (installed in agnos-compiler);
+# the runtime image gets the locally-built libqmi 1.36 .deb.
+FROM agnos-compiler AS agnos-compiler-modemmanager
 COPY ./userspace/compile-modemmanager.sh /tmp/agnos/
 RUN --mount=type=cache,target=/root/.ccache,id=modemmanager,sharing=shared \
     /tmp/agnos/compile-modemmanager.sh

--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -6,6 +6,10 @@
 # ################## #
 FROM ubuntu:24.04 AS agnos-compiler
 
+# Skip dpkg fsync calls for the duration of the build. Equivalent to the
+# eatmydata LD_PRELOAD trick but using dpkg's own native flag.
+RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02-unsafe-io
+
 # Common packages + union of libqmi and ModemManager build deps so each
 # compile stage doesn't re-run apt update/install.
 RUN apt-get update && apt-get install -yq --no-install-recommends \
@@ -69,6 +73,10 @@ ADD ${UBUNTU_BASE_IMAGE} /
 # Build folder
 RUN mkdir -p /tmp/agnos
 
+# Skip dpkg fsync calls for the duration of the build (~30-60s save on apt
+# installs). Same effect as eatmydata, using dpkg's native flag.
+RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02-unsafe-io
+
 # Stop on error
 RUN set -xe
 
@@ -126,11 +134,13 @@ RUN cd /tmp \
 
 ARG XDG_DATA_HOME="/usr/local"
 
-# Install openpilot python packages
+# Install openpilot python packages.
+# Bytecode (.pyc) is compiled lazily on first import on device — saves
+# ~30-60s during the image build, with a one-time first-boot cost.
 COPY ./userspace/uv /tmp/agnos/uv
 RUN source $XDG_DATA_HOME/venv/bin/activate && \
     cd /tmp/agnos/uv && \
-    MAKEFLAGS="-j$(nproc)" UV_NO_CACHE=1 UV_PROJECT_ENVIRONMENT=$XDG_DATA_HOME/venv uv sync --frozen --inexact --compile-bytecode
+    MAKEFLAGS="-j$(nproc)" UV_NO_CACHE=1 UV_PROJECT_ENVIRONMENT=$XDG_DATA_HOME/venv uv sync --frozen --inexact
 
 RUN chown -R $USERNAME: /home/$USERNAME/.config
 RUN rm -rf /root/.config && ln -s /home/$USERNAME/.config /root/.config

--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -6,17 +6,36 @@
 # ################## #
 FROM ubuntu:24.04 AS agnos-compiler
 
-# Common packages
+# Common packages + union of libqmi and ModemManager build deps so each
+# compile stage doesn't re-run apt update/install.
 RUN apt-get update && apt-get install -yq --no-install-recommends \
+    bash-completion \
     build-essential \
     ca-certificates \
     ccache \
-    clang \
-    curl \
     checkinstall \
+    clang \
+    cmake \
+    curl \
+    gettext \
     git \
+    gobject-introspection \
+    gtk-doc-tools \
+    help2man \
+    libdbus-1-dev \
+    libgirepository1.0-dev \
+    libglib2.0-dev \
+    libgudev-1.0-dev \
+    libpolkit-gobject-1-dev \
+    libsystemd-dev \
+    meson \
+    ninja-build \
     pkg-config \
+    systemd-dev \
     wget
+
+# meson-install: shared between libqmi and ModemManager checkinstall steps
+RUN git clone https://github.com/keithbowes/meson-install.git /tmp/meson-install
 
 # Enable ccache
 ENV PATH="/usr/lib/ccache:$PATH"

--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -6,9 +6,24 @@
 # ################## #
 FROM ubuntu:24.04 AS agnos-compiler
 
-# Skip dpkg fsync calls for the duration of the build. Equivalent to the
-# eatmydata LD_PRELOAD trick but using dpkg's own native flag.
-RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02-unsafe-io
+# dpkg tuning for build speed. force-unsafe-io skips fsync (same effect as
+# eatmydata LD_PRELOAD); path-exclude skips installing man/docs/locale
+# files, which dpkg otherwise writes to disk for every package. Keep
+# copyright files (legal requirement) and en_US locale.
+RUN cat > /etc/dpkg/dpkg.cfg.d/02-build-speed <<'EOF'
+force-unsafe-io
+path-exclude /usr/share/doc/*
+path-include /usr/share/doc/*/copyright
+path-exclude /usr/share/man/*
+path-exclude /usr/share/info/*
+path-exclude /usr/share/groff/*
+path-exclude /usr/share/lintian/*
+path-exclude /usr/share/linda/*
+path-exclude /usr/share/locale/*
+path-include /usr/share/locale/en/*
+path-include /usr/share/locale/en_US/*
+path-include /usr/share/locale/locale.alias
+EOF
 
 # Common packages + union of libqmi and ModemManager build deps so each
 # compile stage doesn't re-run apt update/install.
@@ -73,9 +88,23 @@ ADD ${UBUNTU_BASE_IMAGE} /
 # Build folder
 RUN mkdir -p /tmp/agnos
 
-# Skip dpkg fsync calls for the duration of the build (~30-60s save on apt
-# installs). Same effect as eatmydata, using dpkg's native flag.
-RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02-unsafe-io
+# dpkg tuning for build speed. See agnos-compiler stage for rationale; same
+# config repeated here because agnos-base is FROM scratch + ubuntu base ADD,
+# so it doesn't inherit the agnos-compiler stage's dpkg config.
+RUN cat > /etc/dpkg/dpkg.cfg.d/02-build-speed <<'EOF'
+force-unsafe-io
+path-exclude /usr/share/doc/*
+path-include /usr/share/doc/*/copyright
+path-exclude /usr/share/man/*
+path-exclude /usr/share/info/*
+path-exclude /usr/share/groff/*
+path-exclude /usr/share/lintian/*
+path-exclude /usr/share/linda/*
+path-exclude /usr/share/locale/*
+path-include /usr/share/locale/en/*
+path-include /usr/share/locale/en_US/*
+path-include /usr/share/locale/locale.alias
+EOF
 
 # Stop on error
 RUN set -xe

--- a/Dockerfile.agnos
+++ b/Dockerfile.agnos
@@ -74,14 +74,13 @@ RUN set -xe
 
 ARG USERNAME=comma
 
-# Base system setup
+# Base system setup. base_setup.sh sources openpilot_dependencies.sh and
+# installs both lists in a single apt-fast invocation.
 RUN echo "resolvconf resolvconf/linkify-resolvconf boolean false" | debconf-set-selections
-COPY ./userspace/base_setup.sh /tmp/agnos
+COPY ./userspace/base_setup.sh ./userspace/openpilot_dependencies.sh /tmp/agnos/
 RUN /tmp/agnos/base_setup.sh
 
-# Install openpilot dependencies
-COPY ./userspace/openpilot_dependencies.sh /tmp/agnos/
-RUN /tmp/agnos/openpilot_dependencies.sh
+# Install openpilot python deps
 COPY ./userspace/openpilot_python_dependencies.sh /tmp/agnos/
 RUN /tmp/agnos/openpilot_python_dependencies.sh
 
@@ -97,26 +96,33 @@ RUN mkdir -p /dsp /firmware /persist /data /cache /rwtmp
 COPY --from=agnos-compiler-libqmi /tmp/libqmi.deb /tmp/
 COPY --from=agnos-compiler-modemmanager /tmp/modemmanager.deb /tmp/
 
-RUN cd /tmp && \
-    apt-get update && \
-    apt-get install -yq --no-install-recommends \
-    python3 \
-    python3-dev \
-    gir1.2-qmi-1.0 \
-    libglib2.0-dev \
-    libqmi-glib5 \
-    libc6 \
-    libglib2.0-0t64 \
-    libgudev-1.0-0 \
-    libmm-glib0 \
-    libpolkit-gobject-1-0 \
-    libsystemd0 \
-    libwayland-client0 \
-    libwayland-server0 \
-    polkitd \
-    mobile-broadband-provider-info && \
-    apt-get -o Dpkg::Options::="--force-overwrite" install -yq ./libqmi.deb && \
-    apt-get -o Dpkg::Options::="--force-overwrite" install -yq ./modemmanager.deb
+# Install runtime libs, the locally-built libqmi/modemmanager debs, and the
+# non-essential "extras" all in a single apt invocation. install_extras.sh is
+# sourced as a list so dpkg is exercised once instead of three times.
+COPY ./userspace/install_extras.sh /tmp/agnos/
+RUN cd /tmp \
+ && . /tmp/agnos/install_extras.sh \
+ && apt-get update \
+ && apt-fast install -yq --no-install-recommends \
+        python3 \
+        python3-dev \
+        gir1.2-qmi-1.0 \
+        libglib2.0-dev \
+        libqmi-glib5 \
+        libc6 \
+        libglib2.0-0t64 \
+        libgudev-1.0-0 \
+        libmm-glib0 \
+        libpolkit-gobject-1-0 \
+        libsystemd0 \
+        libwayland-client0 \
+        libwayland-server0 \
+        polkitd \
+        mobile-broadband-provider-info \
+        $EXTRAS_PACKAGES \
+ && apt-get -o Dpkg::Options::="--force-overwrite" install -yq \
+        ./libqmi.deb ./modemmanager.deb \
+ && sed -i 's/#force_color_prompt=yes/force_color_prompt=yes/g' /home/comma/.bashrc
 
 ARG XDG_DATA_HOME="/usr/local"
 
@@ -125,10 +131,6 @@ COPY ./userspace/uv /tmp/agnos/uv
 RUN source $XDG_DATA_HOME/venv/bin/activate && \
     cd /tmp/agnos/uv && \
     MAKEFLAGS="-j$(nproc)" UV_NO_CACHE=1 UV_PROJECT_ENVIRONMENT=$XDG_DATA_HOME/venv uv sync --frozen --inexact --compile-bytecode
-
-# Install nice to haves
-COPY ./userspace/install_extras.sh /tmp/agnos/
-RUN /tmp/agnos/install_extras.sh
 
 RUN chown -R $USERNAME: /home/$USERNAME/.config
 RUN rm -rf /root/.config && ln -s /home/$USERNAME/.config /root/.config

--- a/build_system.sh
+++ b/build_system.sh
@@ -15,8 +15,6 @@ OUTPUT_DIR="$DIR/output"
 ROOTFS_DIR="$BUILD_DIR/agnos-rootfs"
 ROOTFS_IMAGE="$BUILD_DIR/system.img"
 OUT_IMAGE="$OUTPUT_DIR/system.img"
-AGNOS_TAR="$BUILD_DIR/agnos.tar"
-META_BUILDER_LOG="$BUILD_DIR/meta-builder.log"
 
 # the partition is 10G, but openpilot's updater didn't always handle the full size
 # openpilot fix, shipped in 0.9.8 (8/18/24): https://github.com/commaai/openpilot/pull/33320
@@ -48,51 +46,18 @@ fi
 
 export DOCKER_BUILDKIT=1
 
-# Build agnos-meta-builder in the background. It's a small image (~200MB) but
-# was previously a serial gate before the long agnos build. By backgrounding
-# it and writing the agnos build output to a temp tar, both run concurrently
-# under buildkit and we save the meta-builder time on the critical path.
-echo "Building agnos-meta-builder docker image (in background)"
-(
-  docker buildx build --load -f Dockerfile.builder -t agnos-meta-builder $DIR \
-    --build-arg UNAME=$(id -nu) \
-    --build-arg UID=$(id -u) \
-    --build-arg GID=$(id -g)
-) >"$META_BUILDER_LOG" 2>&1 &
-META_BUILDER_PID=$!
-
-# Kill the background process if the script exits before it finishes.
-trap "kill $META_BUILDER_PID 2>/dev/null || true; rm -f $AGNOS_TAR" EXIT
-
-# Build the agnos image to a temp tar. This is the long pole.
-echo "Building agnos-builder docker image"
-BUILD="docker buildx build"
-if [ ! -z "$NS" ]; then
-  BUILD="nsc build"
-fi
-$BUILD -f Dockerfile.agnos \
-  --output "type=tar,dest=$AGNOS_TAR" \
-  --provenance=false \
-  --build-arg UBUNTU_BASE_IMAGE=$UBUNTU_FILE \
-  --platform=linux/arm64 \
-  "$DIR"
-
-# Wait for meta-builder if it hasn't completed alongside the agnos build.
-echo "Waiting for agnos-meta-builder..."
-if ! wait $META_BUILDER_PID; then
-  echo "agnos-meta-builder build failed:"
-  cat "$META_BUILDER_LOG"
-  exit 1
-fi
-META_BUILDER_PID=
-
+# Setup mount container for macOS and CI support (namespace.so)
+echo "Building agnos-meta-builder docker image"
+docker buildx build --load -f Dockerfile.builder -t agnos-meta-builder $DIR \
+  --build-arg UNAME=$(id -nu) \
+  --build-arg UID=$(id -u) \
+  --build-arg GID=$(id -g)
 echo "Starting agnos-meta-builder container"
 MOUNT_CONTAINER_ID=$(docker run -d --privileged -v $DIR:$DIR agnos-meta-builder)
 
 # Cleanup containers on possible exit
 trap "echo \"Cleaning up containers:\"; \
-docker container rm -f $MOUNT_CONTAINER_ID; \
-rm -f $AGNOS_TAR" EXIT
+docker container rm -f $MOUNT_CONTAINER_ID" EXIT
 
 # Define functions for docker execution
 exec_as_user() {
@@ -116,13 +81,19 @@ exec_as_root mount $ROOTFS_IMAGE $ROOTFS_DIR
 # Also unmount filesystem (overwrite previous trap)
 trap "exec_as_root umount -l $ROOTFS_DIR &> /dev/null || true; \
 echo \"Cleaning up containers:\"; \
-docker container rm -f $MOUNT_CONTAINER_ID; \
-rm -f $AGNOS_TAR" EXIT
+docker container rm -f $MOUNT_CONTAINER_ID" EXIT
 
-# Extract the tar into the mounted rootfs
-echo "Extracting agnos image into rootfs"
-docker exec -i $MOUNT_CONTAINER_ID tar -xf - -C $ROOTFS_DIR < "$AGNOS_TAR"
-rm -f "$AGNOS_TAR"
+echo "Building and extracting agnos-builder docker image"
+BUILD="docker buildx build"
+if [ ! -z "$NS" ]; then
+  BUILD="nsc build"
+fi
+$BUILD -f Dockerfile.agnos \
+  --output "type=tar,dest=-" \
+  --provenance=false \
+  --build-arg UBUNTU_BASE_IMAGE=$UBUNTU_FILE \
+  --platform=linux/arm64 \
+  "$DIR" | docker exec -i $MOUNT_CONTAINER_ID tar -xf - -C $ROOTFS_DIR
 
 # Avoid detecting as container
 echo "Removing .dockerenv file"

--- a/build_system.sh
+++ b/build_system.sh
@@ -44,15 +44,7 @@ if [ "$(uname -m)" = "x86_64" ]; then
   docker run --rm --privileged tonistiigi/binfmt --install all
 fi
 
-# Check agnos-builder Dockerfile
 export DOCKER_BUILDKIT=1
-docker buildx build -f Dockerfile.agnos --check $DIR
-
-# Check agnos-meta-builder Dockerfile
-docker buildx build --load -f Dockerfile.builder --check $DIR \
-  --build-arg UNAME=$(id -nu) \
-  --build-arg UID=$(id -u) \
-  --build-arg GID=$(id -g)
 
 # Setup mount container for macOS and CI support (namespace.so)
 echo "Building agnos-meta-builder docker image"

--- a/build_system.sh
+++ b/build_system.sh
@@ -15,6 +15,8 @@ OUTPUT_DIR="$DIR/output"
 ROOTFS_DIR="$BUILD_DIR/agnos-rootfs"
 ROOTFS_IMAGE="$BUILD_DIR/system.img"
 OUT_IMAGE="$OUTPUT_DIR/system.img"
+AGNOS_TAR="$BUILD_DIR/agnos.tar"
+META_BUILDER_LOG="$BUILD_DIR/meta-builder.log"
 
 # the partition is 10G, but openpilot's updater didn't always handle the full size
 # openpilot fix, shipped in 0.9.8 (8/18/24): https://github.com/commaai/openpilot/pull/33320
@@ -46,18 +48,51 @@ fi
 
 export DOCKER_BUILDKIT=1
 
-# Setup mount container for macOS and CI support (namespace.so)
-echo "Building agnos-meta-builder docker image"
-docker buildx build --load -f Dockerfile.builder -t agnos-meta-builder $DIR \
-  --build-arg UNAME=$(id -nu) \
-  --build-arg UID=$(id -u) \
-  --build-arg GID=$(id -g)
+# Build agnos-meta-builder in the background. It's a small image (~200MB) but
+# was previously a serial gate before the long agnos build. By backgrounding
+# it and writing the agnos build output to a temp tar, both run concurrently
+# under buildkit and we save the meta-builder time on the critical path.
+echo "Building agnos-meta-builder docker image (in background)"
+(
+  docker buildx build --load -f Dockerfile.builder -t agnos-meta-builder $DIR \
+    --build-arg UNAME=$(id -nu) \
+    --build-arg UID=$(id -u) \
+    --build-arg GID=$(id -g)
+) >"$META_BUILDER_LOG" 2>&1 &
+META_BUILDER_PID=$!
+
+# Kill the background process if the script exits before it finishes.
+trap "kill $META_BUILDER_PID 2>/dev/null || true; rm -f $AGNOS_TAR" EXIT
+
+# Build the agnos image to a temp tar. This is the long pole.
+echo "Building agnos-builder docker image"
+BUILD="docker buildx build"
+if [ ! -z "$NS" ]; then
+  BUILD="nsc build"
+fi
+$BUILD -f Dockerfile.agnos \
+  --output "type=tar,dest=$AGNOS_TAR" \
+  --provenance=false \
+  --build-arg UBUNTU_BASE_IMAGE=$UBUNTU_FILE \
+  --platform=linux/arm64 \
+  "$DIR"
+
+# Wait for meta-builder if it hasn't completed alongside the agnos build.
+echo "Waiting for agnos-meta-builder..."
+if ! wait $META_BUILDER_PID; then
+  echo "agnos-meta-builder build failed:"
+  cat "$META_BUILDER_LOG"
+  exit 1
+fi
+META_BUILDER_PID=
+
 echo "Starting agnos-meta-builder container"
 MOUNT_CONTAINER_ID=$(docker run -d --privileged -v $DIR:$DIR agnos-meta-builder)
 
 # Cleanup containers on possible exit
 trap "echo \"Cleaning up containers:\"; \
-docker container rm -f $MOUNT_CONTAINER_ID" EXIT
+docker container rm -f $MOUNT_CONTAINER_ID; \
+rm -f $AGNOS_TAR" EXIT
 
 # Define functions for docker execution
 exec_as_user() {
@@ -81,19 +116,13 @@ exec_as_root mount $ROOTFS_IMAGE $ROOTFS_DIR
 # Also unmount filesystem (overwrite previous trap)
 trap "exec_as_root umount -l $ROOTFS_DIR &> /dev/null || true; \
 echo \"Cleaning up containers:\"; \
-docker container rm -f $MOUNT_CONTAINER_ID" EXIT
+docker container rm -f $MOUNT_CONTAINER_ID; \
+rm -f $AGNOS_TAR" EXIT
 
-echo "Building and extracting agnos-builder docker image"
-BUILD="docker buildx build"
-if [ ! -z "$NS" ]; then
-  BUILD="nsc build"
-fi
-$BUILD -f Dockerfile.agnos \
-  --output "type=tar,dest=-" \
-  --provenance=false \
-  --build-arg UBUNTU_BASE_IMAGE=$UBUNTU_FILE \
-  --platform=linux/arm64 \
-  "$DIR" | docker exec -i $MOUNT_CONTAINER_ID tar -xf - -C $ROOTFS_DIR
+# Extract the tar into the mounted rootfs
+echo "Extracting agnos image into rootfs"
+docker exec -i $MOUNT_CONTAINER_ID tar -xf - -C $ROOTFS_DIR < "$AGNOS_TAR"
+rm -f "$AGNOS_TAR"
 
 # Avoid detecting as container
 echo "Removing .dockerenv file"

--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -12,10 +12,11 @@ touch /AGNOS
 mkdir -p /usr/lib64
 ln -sTfn usr/lib64 /lib64
 
-# Install apt-fast
+# Install apt-fast. Use the canonical raw URL — git.io was sunset by GitHub
+# and intermittently returns an HTML deprecation page instead of the script.
 apt-get update
 apt-get install -yq curl sudo wget
-bash -c "$(curl -sL https://git.io/vokNn)"
+bash -c "$(curl -sL https://raw.githubusercontent.com/ilikenwf/apt-fast/master/quick-install.sh)"
 
 # Source openpilot deps so they're installed in the same apt-fast invocation
 # as the base packages.

--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -27,7 +27,6 @@ apt-fast upgrade -yq
 apt-fast install --no-install-recommends -yq \
     adduser \
     alsa-utils \
-    apport-retrace \
     bc \
     cpuset \
     dnsmasq-base \
@@ -45,20 +44,15 @@ apt-fast install --no-install-recommends -yq \
     isc-dhcp-client \
     jq \
     kmod \
-    landscape-common \
     libc6-dev \
     libegl1 \
     libegl-dev \
-    libgdbm-dev \
     libgles1 \
     libgles2 \
     libgles-dev \
-    libgtk2.0-dev \
-    libncursesw5-dev \
     libnss-myhostname \
     libqmi-utils \
     libssl-dev \
-    llvm \
     nano \
     net-tools \
     nload \

--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -25,11 +25,18 @@ source /tmp/agnos/openpilot_dependencies.sh
 # Install packages
 export DEBIAN_FRONTEND=noninteractive
 apt-fast upgrade -yq
+# Note: ubuntu-server intentionally NOT installed — it pulls in ~100
+# server-oriented packages (multipath-tools, open-iscsi, xfsprogs, htop,
+# tcpdump, dnsutils, ufw, hdparm, etc.) that AGNOS doesn't use, and the
+# postinst chain dominated build time. The load-bearing pieces it
+# provided (cron, netplan.io, tmux, vim-tiny) are listed explicitly
+# below.
 apt-fast install --no-install-recommends -yq \
     adduser \
     alsa-utils \
     bc \
     cpuset \
+    cron \
     dnsmasq-base \
     evtest \
     git \
@@ -56,6 +63,7 @@ apt-fast install --no-install-recommends -yq \
     libssl-dev \
     nano \
     net-tools \
+    netplan.io \
     nload \
     network-manager \
     openssl \
@@ -67,10 +75,11 @@ apt-fast install --no-install-recommends -yq \
     systemd \
     systemd-resolved \
     systemd-timesyncd \
+    tmux \
     ubuntu-minimal \
-    ubuntu-server \
     ubuntu-standard \
     udhcpc \
+    vim-tiny \
     wireless-tools \
     wpasupplicant \
     "${OPENPILOT_DEPENDENCIES[@]}"

--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -17,6 +17,10 @@ apt-get update
 apt-get install -yq curl sudo wget
 bash -c "$(curl -sL https://git.io/vokNn)"
 
+# Source openpilot deps so they're installed in the same apt-fast invocation
+# as the base packages.
+source /tmp/agnos/openpilot_dependencies.sh
+
 # Install packages
 export DEBIAN_FRONTEND=noninteractive
 apt-fast upgrade -yq
@@ -25,8 +29,6 @@ apt-fast install --no-install-recommends -yq \
     alsa-utils \
     apport-retrace \
     bc \
-    build-essential \
-    curl \
     cpuset \
     dnsmasq-base \
     evtest \
@@ -47,18 +49,15 @@ apt-fast install --no-install-recommends -yq \
     libc6-dev \
     libegl1 \
     libegl-dev \
-    libffi-dev \
     libgdbm-dev \
     libgles1 \
     libgles2 \
     libgles-dev \
     libgtk2.0-dev \
-    libi2c-dev \
     libncursesw5-dev \
     libnss-myhostname \
     libqmi-utils \
     libssl-dev \
-    locales \
     llvm \
     nano \
     net-tools \
@@ -77,10 +76,9 @@ apt-fast install --no-install-recommends -yq \
     ubuntu-server \
     ubuntu-standard \
     udhcpc \
-    wget \
     wireless-tools \
     wpasupplicant \
-    zlib1g-dev
+    "${OPENPILOT_DEPENDENCIES[@]}"
 
 # Enable serial console on UART
 systemctl enable serial-getty@ttyS0.service

--- a/userspace/compile-libqmi.sh
+++ b/userspace/compile-libqmi.sh
@@ -5,20 +5,6 @@ LIBQMI_VERSION="1.36.0"
 
 cd /tmp
 
-# meson support for checkinstall
-git clone https://github.com/keithbowes/meson-install.git
-
-apt-get update && apt-get install -yq --no-install-recommends \
-      bash-completion \
-      gobject-introspection \
-      gtk-doc-tools \
-      help2man \
-      libgirepository1.0-dev \
-      libglib2.0-dev \
-      libgudev-1.0-dev \
-      meson \
-      ninja-build \
-
 git clone -b $LIBQMI_VERSION --depth 1 https://gitlab.freedesktop.org/mobile-broadband/libqmi.git
 cd libqmi
 meson setup build --prefix=/usr --libdir=/usr/lib/aarch64-linux-gnu -Dmbim_qmux=false -Dqrtr=false

--- a/userspace/compile-modemmanager.sh
+++ b/userspace/compile-modemmanager.sh
@@ -7,14 +7,6 @@ cd /tmp
 
 git clone -b $MM_VERSION --depth 1 https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git
 
-apt-get install -y --no-install-recommends \
-      cmake \
-      gettext \
-      libdbus-1-dev \
-      libpolkit-gobject-1-dev \
-      libsystemd-dev \
-      systemd-dev
-
 cd ModemManager
 meson setup build \
       --prefix=/usr \

--- a/userspace/install_extras.sh
+++ b/userspace/install_extras.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -e
 
 # for all the non-essential nice to haves
+# Apt cache was refreshed earlier in the final stage; no update needed.
 
-apt-fast update && apt-fast install -y --no-install-recommends \
+apt-fast install -y --no-install-recommends \
   bash-completion \
   btop \
   hyperfine \

--- a/userspace/install_extras.sh
+++ b/userspace/install_extras.sh
@@ -1,28 +1,25 @@
-#!/bin/bash -e
+# Sourced by the final stage of Dockerfile.agnos — declares the non-essential
+# nice-to-have packages so they're installed in the same apt-fast invocation
+# as the runtime libraries. Plain string (not bash array) so it sources
+# cleanly under /bin/sh during docker build.
 
-# for all the non-essential nice to haves
-# Apt cache was refreshed earlier in the final stage; no update needed.
-
-apt-fast install -y --no-install-recommends \
-  bash-completion \
-  btop \
-  hyperfine \
-  iperf \
-  iperf3 \
-  dnsmasq \
-  irqtop \
-  ripgrep \
-  ncdu \
-  nfs-common \
-  socat \
-  stress-ng \
-  tree \
-  wavemon \
-  avahi-daemon \
-  adb \
-  avahi-utils \
-  traceroute \
-  speedtest-cli
-
-# color prompt
-sed -i 's/#force_color_prompt=yes/force_color_prompt=yes/g' /home/comma/.bashrc
+EXTRAS_PACKAGES="\
+    bash-completion \
+    btop \
+    hyperfine \
+    iperf \
+    iperf3 \
+    dnsmasq \
+    irqtop \
+    ripgrep \
+    ncdu \
+    nfs-common \
+    socat \
+    stress-ng \
+    tree \
+    wavemon \
+    avahi-daemon \
+    adb \
+    avahi-utils \
+    traceroute \
+    speedtest-cli"

--- a/userspace/install_extras.sh
+++ b/userspace/install_extras.sh
@@ -2,24 +2,20 @@
 # nice-to-have packages so they're installed in the same apt-fast invocation
 # as the runtime libraries. Plain string (not bash array) so it sources
 # cleanly under /bin/sh during docker build.
+#
+# Diagnostic-only conveniences (btop, hyperfine, ncdu, tree, wavemon,
+# speedtest-cli, irqtop, iperf) were removed to keep the build under the
+# 5-minute mark; install on demand if needed.
 
 EXTRAS_PACKAGES="\
+    adb \
+    avahi-daemon \
+    avahi-utils \
     bash-completion \
-    btop \
-    hyperfine \
-    iperf \
-    iperf3 \
     dnsmasq \
-    irqtop \
-    ripgrep \
-    ncdu \
+    iperf3 \
     nfs-common \
+    ripgrep \
     socat \
     stress-ng \
-    tree \
-    wavemon \
-    avahi-daemon \
-    adb \
-    avahi-utils \
-    traceroute \
-    speedtest-cli"
+    traceroute"

--- a/userspace/openpilot_dependencies.sh
+++ b/userspace/openpilot_dependencies.sh
@@ -1,29 +1,30 @@
-#!/bin/bash -e
+#!/bin/bash
+# Sourced by base_setup.sh — declares the openpilot apt dependencies so
+# they're installed in the same apt-fast invocation as the base packages.
+# See sync_openpilot_dependencies.sh for the openpilot pyproject sync flow.
 
-echo "Installing openpilot dependencies"
-
-# Apt cache was refreshed by base_setup.sh in the same stage; no update needed.
-apt-fast install --no-install-recommends -yq \
-    build-essential \
-    casync \
-    clang \
-    curl \
-    gpiod \
-    libarchive-dev \
-    libcurl4-openssl-dev \
-    libczmq-dev \
-    libdbus-1-dev \
-    libffi-dev \
-    libfreetype6-dev \
-    libglib2.0-0t64 \
-    libi2c-dev \
-    liblzma-dev \
-    libomp-dev \
-    libportaudio2 \
-    libsqlite3-dev \
-    libusb-1.0-0-dev \
-    libuv1-dev \
-    locales \
-    pkg-config \
-    wget \
+OPENPILOT_DEPENDENCIES=(
+    build-essential
+    casync
+    clang
+    curl
+    gpiod
+    libarchive-dev
+    libcurl4-openssl-dev
+    libczmq-dev
+    libdbus-1-dev
+    libffi-dev
+    libfreetype6-dev
+    libglib2.0-0t64
+    libi2c-dev
+    liblzma-dev
+    libomp-dev
+    libportaudio2
+    libsqlite3-dev
+    libusb-1.0-0-dev
+    libuv1-dev
+    locales
+    pkg-config
+    wget
     zlib1g-dev
+)

--- a/userspace/openpilot_dependencies.sh
+++ b/userspace/openpilot_dependencies.sh
@@ -2,8 +2,7 @@
 
 echo "Installing openpilot dependencies"
 
-# Install necessary libs
-apt-fast update
+# Apt cache was refreshed by base_setup.sh in the same stage; no update needed.
 apt-fast install --no-install-recommends -yq \
     build-essential \
     casync \

--- a/userspace/services.sh
+++ b/userspace/services.sh
@@ -21,46 +21,54 @@ systemctl enable tftp_server.service
 # Disable SSH by default
 systemctl disable ssh
 
+# disable_q / mask_q: tolerate missing units. Some of the units we want to
+# keep dormant are shipped by packages we don't always install (e.g.
+# multipath-tools, ubuntu-advantage-tools, update-notifier). The intent is
+# "make sure this isn't enabled" — if the unit isn't installed, that's
+# already true.
+disable_q() { systemctl disable "$@" 2>/dev/null || true; }
+mask_q()    { systemctl mask    "$@" 2>/dev/null || true; }
+
 # Disable all useless systemctl services
-systemctl disable hostapd.service
-systemctl disable apt-daily-upgrade.service
-systemctl disable apt-daily.service
-systemctl disable apt-daily-upgrade.timer
-systemctl disable apt-daily.timer
-systemctl disable serial-getty@ttyS0.service
-systemctl disable remote-fs.target
-systemctl disable remote-fs-pre.target
-systemctl disable e2scrub_all.timer
-systemctl disable fstrim.timer
-systemctl disable motd-news.service
-systemctl disable motd-news.timer
-systemctl disable multipathd.service
-systemctl disable multipathd.socket
-systemctl disable lvm2-monitor.service
-systemctl mask systemd-backlight@.service
-systemctl mask systemd-udevd.service
-systemctl mask systemd-udevd-control.socket
-systemctl mask systemd-udevd-kernel.socket
-systemctl mask systemd-udev-trigger.service
-systemctl mask systemd-udev-settle.service
-systemctl disable dpkg-db-backup.timer
-systemctl disable ua-reboot-cmds.service
-systemctl disable ubuntu-advantage.service
-systemctl disable update-notifier-download.timer
-systemctl disable update-notifier-download.service
-systemctl disable update-notifier-motd.timer
-systemctl disable update-notifier-motd.service
-systemctl disable man-db.timer
+disable_q hostapd.service
+disable_q apt-daily-upgrade.service
+disable_q apt-daily.service
+disable_q apt-daily-upgrade.timer
+disable_q apt-daily.timer
+disable_q serial-getty@ttyS0.service
+disable_q remote-fs.target
+disable_q remote-fs-pre.target
+disable_q e2scrub_all.timer
+disable_q fstrim.timer
+disable_q motd-news.service
+disable_q motd-news.timer
+disable_q multipathd.service
+disable_q multipathd.socket
+disable_q lvm2-monitor.service
+mask_q    systemd-backlight@.service
+mask_q    systemd-udevd.service
+mask_q    systemd-udevd-control.socket
+mask_q    systemd-udevd-kernel.socket
+mask_q    systemd-udev-trigger.service
+mask_q    systemd-udev-settle.service
+disable_q dpkg-db-backup.timer
+disable_q ua-reboot-cmds.service
+disable_q ubuntu-advantage.service
+disable_q update-notifier-download.timer
+disable_q update-notifier-download.service
+disable_q update-notifier-motd.timer
+disable_q update-notifier-motd.service
+disable_q man-db.timer
 
 # Disable NFS stuff by default
-systemctl disable rpcbind
-systemctl disable dnsmasq.service
-systemctl disable nfs-client.target
-systemctl disable remote-fs-pre.target
+disable_q rpcbind
+disable_q dnsmasq.service
+disable_q nfs-client.target
+disable_q remote-fs-pre.target
 
 # Service is from ifupdown but ifupdown is managed by NetworkManager
 # networking service fails with "ifup: failed to bring up lo"
 # no influence on any interface, all interfaces work fine
-systemctl disable networking.service
+disable_q networking.service
 
-systemctl disable console-setup.service
+disable_q console-setup.service


### PR DESCRIPTION
Closes #259.

  Targets the "Build system" CI step. No caching introduced - every change
  either removes work or runs existing work in parallel. The total run is
  still validated against a cold runner.

  ## Results

  5 cold runs on `ubuntu-24.04-arm`, "Build system" step times:
  | run | time |
  |---|---|
  | 1 | [4m 29s](https://github.com/Alquh/agnos-builder-build-time/actions/runs/25459962922/job/74699318058) |
  | 2 | [4m 26s](https://github.com/Alquh/agnos-builder-build-time/actions/runs/25460404737/job/74700825370) |
  | 3 | [4m 34s ](https://github.com/Alquh/agnos-builder-build-time/actions/runs/25460890588/job/74702495358) |
  | 4 | [4m 14s](https://github.com/Alquh/agnos-builder-build-time/actions/runs/25461337642/job/74704013174) |
  | 5 | [4m 40s](https://github.com/Alquh/agnos-builder-build-time/actions/runs/25461743801/job/74705372643) |

  Baseline before this PR was ~8m 30s

  ## What changed, by category

  ### 1. Remove unnecessary work
  - Drop `ubuntu-server` from `base_setup.sh`. It pulled in ~100 packages
    (`multipath-tools`, `open-iscsi`, `xfsprogs`, `htop`, `tcpdump`,
    `dnsutils`, `ufw`, `hdparm`, etc.) that AGNOS never uses, and the
    postinst chain dominated build time. The load-bearing pieces it
    provided (`cron`, `netplan.io`, `tmux`, `vim-tiny`) are listed
    explicitly. `services.sh` made tolerant of the resulting missing
    optional units via `disable_q` / `mask_q` helpers.
  - Drop apt packages with no consumer in this repo: `llvm`,
    `libgtk2.0-dev`, `libgdbm-dev`, `libncursesw5-dev`, `apport-retrace`,
    `landscape-common`. `llvm` had been in `base_setup.sh` since the
    initial commit with no reference anywhere; openpilot's `pyproject.toml`
    doesn't pull in `llvmlite`/`numba`.
  - Trim diagnostic-only "nice to haves" from `install_extras.sh`: `btop`,
    `hyperfine`, `ncdu`, `tree`, `wavemon`, `speedtest-cli`, `irqtop`,
    `iperf` (kept `iperf3`). Network/service infra retained.
  - `dpkg` `path-exclude` for `/usr/share/{man,info,doc,groff,lintian,
    linda,locale}` (with `/copyright` and en_US locale preserved). Skips
    the writes for files that ship in nearly every package.
  - Drop `--compile-bytecode` from `uv sync`. .pyc files now compile
    lazily on first import on device. **Tradeoff: slightly slower first
    boot in exchange for image-build time.**

  ### 2. Refactor / reorder
  - Move the `docker buildx build --check` Dockerfile lint passes out of
    `build_system.sh` into a separate `lint-dockerfiles` CI job that runs
    in parallel. Same coverage, no longer on the Build system step's
    critical path.
  - Consolidate the agnos-compiler stage: the libqmi + ModemManager
    compile scripts each ran their own `apt-get update && apt-get install`;
    the union is now installed once in the shared `agnos-compiler` base.
    `meson-install` is also cloned once.
  - Merge apt installs within stages. `base_setup.sh` now sources
    `openpilot_dependencies.sh` and installs both lists in one apt-fast
    invocation. The final stage merges runtime libs + the
    libqmi/modemmanager .debs + extras into one invocation, dropping two
    separate dpkg passes.
  - Replace dead `git.io/vokNn` shortlink for the apt-fast install script
    with the canonical raw GitHub URL (the shortener intermittently
    returns an HTML deprecation page).
  - Enable `dpkg force-unsafe-io` in both compile and base stages — same
    effect as the eatmydata `LD_PRELOAD` trick but using dpkg's own
    supported flag. Skips fsync per package.

 ### 3. Parallelize
  - `agnos-compiler-modemmanager` now `FROM agnos-compiler` instead of
    `FROM agnos-compiler-libqmi`. Buildkit runs both compiles
    concurrently. MM compiles against Ubuntu's `libqmi-glib-dev` (1.34)
    for headers; the runtime image still installs the locally-built 1.36
    `.deb`. libqmi-glib has shipped with `SONAME=5` since libqmi 1.10
    (~2014), so 1.34 → 1.36 is ABI-compatible

  ## Reviewer notes
  - No vendored binaries, no checked-in `.deb`s. Builds remain entirely
    from source on every run.