### PR TITLE
Fix alias paths for command `op` and `dump`

### DIFF
--- a/userspace/root/home/comma/.bash_aliases
+++ b/userspace/root/home/comma/.bash_aliases
@@ -6,5 +6,5 @@ alias gcam='git commit -a -m'
 alias gst='git status'
 alias gco='git checkout'
 alias gsu='git submodule update'
-alias dump="/data/pythonpath/selfdrive/debug/dump.py"
-alias op='/data/openpilot/tools/op.sh "$@"'
+alias dump="/data/openpilot/openpilot/tools/scripts/dump.py"
+alias op='/data/openpilot/openpilot/tools/op.sh "$@"'


### PR DESCRIPTION
## Summary
- Update the default `dump` alias to the current script path.
- Update the default `op` alias to the nested openpilot path.

## Symptom

```
comma@comma-1deee0d7:/data/pythonpath$ op
-bash: /data/openpilot/tools/op.sh: No such file or directory
```

## Why
- `commaai/openpilot@5edc0bd` / commaai/openpilot#38219 moved root directories into the nested `openpilot/` package layout, including `tools/op.sh` and `tools/scripts/dump.py`.
- `commaai/openpilot@20e0f21` / commaai/openpilot#38223 followed up by prefixing paths for the new layout.
- The AGNOS default aliases still point at the pre-move paths, so fresh shells can resolve aliases to missing files after updating openpilot.

## Test
- Checked the PR only changes `userspace/root/home/comma/.bash_aliases`.
- Verified the new target paths exist on a current comma 4 openpilot checkout.