### PR TITLE
lte/gpio: resolve TLMM pins against the gpiochip base

### DIFF
--- a/userspace/root/usr/comma/comma-init.sh
+++ b/userspace/root/usr/comma/comma-init.sh
@@ -198,7 +198,11 @@ function init_gpio (
     1264  # POWER ALERT
   )
 
+  tlmm_base=$(cat /sys/bus/platform/devices/3400000.pinctrl/gpio/*/base 2>/dev/null | head -1)
+  tlmm_base=${tlmm_base:-0}
+
   for p in "${pins[@]}"; do
+    (( p < 150 )) && p=$((p + tlmm_base))
     echo "$p" > /sys/class/gpio/export
   done
 

--- a/userspace/root/usr/comma/lte/lte.sh
+++ b/userspace/root/usr/comma/lte/lte.sh
@@ -5,9 +5,12 @@ function gpio {
   echo $2 > /sys/class/gpio/gpio$1/value
 }
 
-LTE_RST_N=50
-LTE_BOOT=52
-LTE_PWRKEY=116
+tlmm_base=$(cat /sys/bus/platform/devices/3400000.pinctrl/gpio/*/base 2>/dev/null | head -1)
+tlmm_base=${tlmm_base:-0}
+
+LTE_RST_N=$((tlmm_base + 50))
+LTE_BOOT=$((tlmm_base + 52))
+LTE_PWRKEY=$((tlmm_base + 116))
 
 function is_modem_up {
   if lsusb -d "0x05c6:" >/dev/null 2>&1 || lsusb -d "0x2c7c:" >/dev/null 2>&1; then


### PR DESCRIPTION
TLMM pin numbers only work as absolute sysfs GPIO numbers when the chip's base is 0 (downstream); on mainline the base is dynamic, so resolve pins against the 3400000.pinctrl gpiochip base.

Mirrors what vamOS userspace already does: https://github.com/commaai/vamOS/blob/9bd8869/userspace/root/usr/comma/gpio_base.sh