### PR TITLE
Added MTP to agnos

### DIFF
--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -81,7 +81,7 @@ apt-fast install --no-install-recommends -yq \
     wireless-tools \
     wpasupplicant \
     zlib1g-dev  \
-    umtprd
+    umtp-responder
 
 # Enable serial console on UART
 systemctl enable serial-getty@ttyS0.service

--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -80,7 +80,8 @@ apt-fast install --no-install-recommends -yq \
     wget \
     wireless-tools \
     wpasupplicant \
-    zlib1g-dev
+    zlib1g-dev  \
+    umtprd
 
 # Enable serial console on UART
 systemctl enable serial-getty@ttyS0.service

--- a/userspace/root/etc/umtprd/umtprd.conf
+++ b/userspace/root/etc/umtprd/umtprd.conf
@@ -1,0 +1,11 @@
+manufacturer = comma.ai
+product = Linux USB Gadget
+serial = 0x1234
+
+[MTP]
+usb_max_packet_len = 512
+usb_functionfs_path = /dev/usb-ffs/mtp
+
+[STORAGE]
+name = Recordings
+storage = /data/media/0/realdata

--- a/userspace/root/usr/comma/set_adb.sh
+++ b/userspace/root/usr/comma/set_adb.sh
@@ -1,29 +1,7 @@
 #!/bin/bash
 
 setup() {
-  # Check if /config is already mounted
-  if ! mountpoint -q /config; then
-    sudo mount -t configfs none /config
-  else
-    echo "/config is already mounted."
-  fi
-
-  # Create USB gadget directory structure
-  sudo mkdir -p /config/usb_gadget/g1
   cd /config/usb_gadget/g1
-  sudo mkdir -p strings/0x409
-  sudo mkdir -p configs/c.1/strings/0x409
-  sudo mkdir -p functions/ncm.0
-
-  # Set Vendor and Product ID
-  echo 0x04D8 | sudo tee idVendor
-  echo 0x1234 | sudo tee idProduct
-
-  # Set strings
-  echo "$(cat /proc/cmdline | sed -e 's/^.*androidboot.serialno=//' -e 's/ .*$//')" | sudo tee strings/0x409/serialnumber
-  echo "comma.ai" | sudo tee strings/0x409/manufacturer
-  echo "Linux USB Gadget" | sudo tee strings/0x409/product
-  echo 250 | sudo tee configs/c.1/MaxPower
 
   # Create ADB function
   sudo mkdir -p functions/ffs.adb
@@ -34,11 +12,7 @@ setup() {
     echo "/dev/usb-ffs/adb is already mounted"
   fi
 
-  # Link both functions to configuration
-  echo "NCM+ADB" | sudo tee configs/c.1/strings/0x409/configuration
-  sudo rm -f configs/c.1/ncm.0
-  sudo rm -f configs/c.1/ffs.adb
-  sudo ln -s functions/ncm.0 configs/c.1/
+  # Link ADB functions to configuration
   sudo ln -s functions/ffs.adb configs/c.1/
 }
 
@@ -46,6 +20,7 @@ start() {
   setprop service.adb.tcp.port -1
 
   cd /config/usb_gadget/g1
+  echo "" | sudo tee UDC
   echo "a600000.dwc3" | sudo tee UDC
 }
 
@@ -53,6 +28,8 @@ stop() {
   if [ -d "/config/usb_gadget/g1" ]; then
     cd /config/usb_gadget/g1
     echo "" | sudo tee UDC
+    sudo rm -f configs/c.1/ffs.adb
+    echo "a600000.dwc3" | sudo tee UDC
   fi
 }
 

--- a/userspace/root/usr/comma/set_mtp.sh
+++ b/userspace/root/usr/comma/set_mtp.sh
@@ -23,33 +23,22 @@ setup() {
   echo "$(cat /proc/cmdline | sed -e 's/^.*androidboot.serialno=//' -e 's/ .*$//')" | sudo tee strings/0x409/serialnumber
   echo "comma.ai" | sudo tee strings/0x409/manufacturer
   echo "Linux USB Gadget" | sudo tee strings/0x409/product
-  echo 250 | sudo tee configs/c.1/MaxPower
-
-  # Create ADB function
-  sudo mkdir -p functions/ffs.adb
-  sudo mkdir -p /dev/usb-ffs/adb
-  if ! mountpoint -q /dev/usb-ffs/adb; then
-    sudo mount -t functionfs adb /dev/usb-ffs/adb
-  else
-    echo "/dev/usb-ffs/adb is already mounted"
-  fi
+  echo 500 | sudo tee configs/c.1/MaxPower
 
   # Create MTP function
-  sudo mkdir -p functions/ffs.adb
-  sudo mkdir -p /dev/usb-ffs/adb
-  if ! moutpoint -q /dev/usb-ffs/mtp; then
-    sudo mount -t functionsfs mtp /dev/usb-ffs/mtp
-  else 
+  sudo mkdir -p functions/ffs.mtp
+  sudo mkdir -p /dev/usb-ffs/mtp
+  if ! mountpoint -q /dev/usb-ffs/mtp; then
+    sudo mount -t functionfs mtp /dev/usb-ffs/mtp
+  else
     echo "/dev/usb-ffs/mtp is already mounted"
   fi
 
-  # Link both functions to configuration
-  echo "NCM+ADB" | sudo tee configs/c.1/strings/0x409/configuration
+  # Link both functions into configuration
+  echo "NCM+MTP" | sudo tee configs/c.1/strings/0x409/configuration
   sudo rm -f configs/c.1/ncm.0
-  sudo rm -f configs/c.1/ffs.adb
   sudo rm -f configs/c.1/ffs.mtp
   sudo ln -s functions/ncm.0 configs/c.1/
-  sudo ln -s functions/ffs.adb configs/c.1/
   sudo ln -s functions/ffs.mtp configs/c.1/
 }
 

--- a/userspace/root/usr/comma/set_mtp.sh
+++ b/userspace/root/usr/comma/set_mtp.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+setup() {
+  # Check if /config is already mounted
+  if ! mountpoint -q /config; then
+    sudo mount -t configfs none /config
+  else
+    echo "/config is already mounted."
+  fi
+
+  # Create USB gadget directory structure
+  sudo mkdir -p /config/usb_gadget/g1
+  cd /config/usb_gadget/g1
+  sudo mkdir -p strings/0x409
+  sudo mkdir -p configs/c.1/strings/0x409
+  sudo mkdir -p functions/ncm.0
+
+  # Set Vendor and Product ID
+  echo 0x04D8 | sudo tee idVendor
+  echo 0x1234 | sudo tee idProduct
+
+  # Set strings
+  echo "$(cat /proc/cmdline | sed -e 's/^.*androidboot.serialno=//' -e 's/ .*$//')" | sudo tee strings/0x409/serialnumber
+  echo "comma.ai" | sudo tee strings/0x409/manufacturer
+  echo "Linux USB Gadget" | sudo tee strings/0x409/product
+  echo 250 | sudo tee configs/c.1/MaxPower
+
+  # Create ADB function
+  sudo mkdir -p functions/ffs.adb
+  sudo mkdir -p /dev/usb-ffs/adb
+  if ! mountpoint -q /dev/usb-ffs/adb; then
+    sudo mount -t functionfs adb /dev/usb-ffs/adb
+  else
+    echo "/dev/usb-ffs/adb is already mounted"
+  fi
+
+  # Create MTP function
+  sudo mkdir -p functions/ffs.adb
+  sudo mkdir -p /dev/usb-ffs/adb
+  if ! moutpoint -q /dev/usb-ffs/mtp; then
+    sudo mount -t functionsfs mtp /dev/usb-ffs/mtp
+  else 
+    echo "/dev/usb-ffs/mtp is already mounted"
+  fi
+
+  # Link both functions to configuration
+  echo "NCM+ADB" | sudo tee configs/c.1/strings/0x409/configuration
+  sudo rm -f configs/c.1/ncm.0
+  sudo rm -f configs/c.1/ffs.adb
+  sudo rm -f configs/c.1/ffs.mtp
+  sudo ln -s functions/ncm.0 configs/c.1/
+  sudo ln -s functions/ffs.adb configs/c.1/
+  sudo ln -s functions/ffs.mtp configs/c.1/
+}
+
+start() {
+  cd /config/usb_gadget/g1
+  echo "a600000.dwc3" | sudo tee UDC
+}
+
+stop() {
+  if [ -d "/config/usb_gadget/g1" ]; then
+    cd /config/usb_gadget/g1
+    echo "" | sudo tee UDC
+  fi
+}
+
+setup
+systemctl start umtprd
+sleep 1
+
+start

--- a/userspace/root/usr/lib/systemd/system/mtp-watcher.service
+++ b/userspace/root/usr/lib/systemd/system/mtp-watcher.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=MTP USB gadget setup
+After=fs_setup.service
+Requires=fs_setup.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/comma/set_mtp.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/userspace/root/usr/lib/systemd/system/umtprd.service
+++ b/userspace/root/usr/lib/systemd/system/umtprd.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=uMTP Responder
+After=comma-init.service
+Requires=comma-init.service
+
+[Service]
+ExecStart=/usr/bin/umtprd -c /etc/umtprd/umtprd.conf
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/userspace/root/usr/lib/systemd/system/umtprd.service
+++ b/userspace/root/usr/lib/systemd/system/umtprd.service
@@ -7,6 +7,3 @@ Requires=comma-init.service
 ExecStart=/usr/bin/umtprd -c /etc/umtprd/umtprd.conf
 Restart=on-failure
 RestartSec=2
-
-[Install]
-WantedBy=multi-user.target

--- a/userspace/services.sh
+++ b/userspace/services.sh
@@ -17,6 +17,7 @@ systemctl enable logrotate-hourly.timer
 systemctl enable avahi-daemon
 systemctl enable avahi-ssh-publish.service
 systemctl enable tftp_server.service
+systemctl enable umtprd.service
 
 # Disable SSH by default
 systemctl disable ssh

--- a/userspace/services.sh
+++ b/userspace/services.sh
@@ -17,7 +17,7 @@ systemctl enable logrotate-hourly.timer
 systemctl enable avahi-daemon
 systemctl enable avahi-ssh-publish.service
 systemctl enable tftp_server.service
-systemctl enable umtprd.service
+systemctl enable mtp-watcher.service
 
 # Disable SSH by default
 systemctl disable ssh


### PR DESCRIPTION
This PR aims to solve https://github.com/commaai/openpilot/issues/38291 by adding MTP support in agnos. MTP is already set to start by default on boot and will expose `realdata` to the supported MTP hosts ( windows, linux support it natively while macos will require openmtp). 