### PR TITLE
Enable scheduler boost by default

### DIFF
--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -88,6 +88,7 @@ systemctl enable serial-getty@ttyS0.service
 # set kernel params
 echo "net.ipv4.conf.all.rp_filter = 2" >> /etc/sysctl.conf
 echo "vm.dirty_expire_centisecs = 200" >> /etc/sysctl.conf
+echo "kernel.sched_boost = 1" >> /etc/sysctl.conf
 
 # raise comma user's process priority limits
 echo "comma - rtprio 100" >> /etc/security/limits.conf


### PR DESCRIPTION


- `sched_boost=0`: 17/20 runs placed on CPU 0, 1.7147 ms median
- `sched_boost=1`: 20/20 runs placed on CPU 5, 1.0431 ms median


```
  import ctypes, os, time
  import numpy as np

  cpu = ctypes.CDLL(None).sched_getcpu
  a = np.ones((176, 176), dtype=np.float32)
  out = np.empty_like(a)

  for _ in range(20):
    np.matmul(a, a, out=out)

  times, cores = [], []
  for _ in range(20):
    time.sleep(0.05)
    cores.append(cpu())
    start = time.perf_counter()
    np.matmul(a, a, out=out)
    times.append((time.perf_counter() - start) * 1000)

  print("affinity:", sorted(os.sched_getaffinity(0)))
  print("cores:", cores)
  print("times_ms:", [round(t, 4) for t in times])
  print("median_ms:", round(float(np.median(times)), 4))
  ```

ran like:
```
  sudo sysctl -w kernel.sched_boost=0
  OPENBLAS_NUM_THREADS=1 .venv/bin/python benchmark.py

  sudo sysctl -w kernel.sched_boost=1
  OPENBLAS_NUM_THREADS=1 .venv/bin/python benchmark.py

```

