### PR TITLE
Add read-only USB footage storage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,10 +21,20 @@ jobs:
         lfs: true
         submodules: true
 
+    - name: Install USB storage integration dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends dosfstools libnbd-bin mtools nbdkit
+
     - name: Test userspace helpers
       env:
         PYTHONDONTWRITEBYTECODE: "1"
       run: python3 -m unittest discover -s userspace/tests -p 'test_*.py' -v
+
+    - name: Test installed nbdkit FAT export
+      env:
+        PYTHONDONTWRITEBYTECODE: "1"
+      run: python3 userspace/tests/integration_usb_storage_nbdkit.py
 
     - name: Get commit message
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,11 @@ jobs:
         lfs: true
         submodules: true
 
+    - name: Test userspace helpers
+      env:
+        PYTHONDONTWRITEBYTECODE: "1"
+      run: python3 -m unittest discover -s userspace/tests -p 'test_*.py' -v
+
     - name: Get commit message
       run: |
         {

--- a/userspace/base_setup.sh
+++ b/userspace/base_setup.sh
@@ -30,6 +30,7 @@ apt-fast install --no-install-recommends -yq \
     cpuset \
     dnsmasq-base \
     evtest \
+    fuse3 \
     git \
     git-core \
     git-lfs \
@@ -55,12 +56,14 @@ apt-fast install --no-install-recommends -yq \
     libgtk2.0-dev \
     libi2c-dev \
     libncursesw5-dev \
+    libnbd-bin \
     libnss-myhostname \
     libqmi-utils \
     libssl-dev \
     locales \
     llvm \
     nano \
+    nbdkit \
     net-tools \
     nload \
     network-manager \

--- a/userspace/root/usr/comma/cleanup_usb_storage.py
+++ b/userspace/root/usr/comma/cleanup_usb_storage.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Remove only a stopped USB storage service's narrowly owned artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from usb_storage import MANAGED_MOUNT_DIRECTORY, MANAGED_MOUNT_NAME, SnapshotBuilder, StorageError
+
+
+def _decode_mountinfo_field(value: str) -> str:
+  for encoded, decoded in ((r"\040", " "), (r"\011", "\t"), (r"\012", "\n"), (r"\134", "\\")):
+    value = value.replace(encoded, decoded)
+  return value
+
+
+def _mountinfo_entries(
+  mountpoint: Path,
+  *,
+  mountinfo: Path = Path("/proc/self/mountinfo"),
+) -> tuple[tuple[str, str], ...]:
+  """Return (filesystem type, source) for exact stacked mounts at mountpoint."""
+  try:
+    lines = mountinfo.read_text().splitlines()
+  except OSError as exc:
+    raise StorageError(f"cannot inspect kernel mount table: {exc}") from exc
+
+  entries: list[tuple[str, str]] = []
+  for line in lines:
+    left, separator, right = line.partition(" - ")
+    left_fields = left.split()
+    right_fields = right.split()
+    if not separator or len(left_fields) < 6 or len(right_fields) < 2:
+      raise StorageError("kernel mount table contains a malformed entry")
+    if _decode_mountinfo_field(left_fields[4]) == str(mountpoint):
+      entries.append((right_fields[0], _decode_mountinfo_field(right_fields[1])))
+  return tuple(entries)
+
+
+class StoppedStorageCleanup:
+  """Clean stale FUSE and snapshot state after systemd killed the cgroup."""
+
+  def __init__(
+    self,
+    *,
+    source: str | os.PathLike[str],
+    snapshot: str | os.PathLike[str],
+    mount: str | os.PathLike[str],
+    unmount_timeout: float = 5.0,
+    command_runner: Callable[..., Any] = subprocess.run,
+    mount_inspector: Callable[[Path], tuple[tuple[str, str], ...]] = _mountinfo_entries,
+  ):
+    self.snapshot_builder = SnapshotBuilder(source, snapshot)
+    requested_mount = Path(mount)
+    if not requested_mount.is_absolute():
+      raise StorageError("managed FUSE path must be absolute")
+    if requested_mount.name != MANAGED_MOUNT_NAME or requested_mount.parent.name != MANAGED_MOUNT_DIRECTORY:
+      raise StorageError(f"refusing unmanaged FUSE path (expected .../{MANAGED_MOUNT_DIRECTORY}/{MANAGED_MOUNT_NAME})")
+    if ".." in requested_mount.parts:
+      raise StorageError("managed FUSE path must not contain parent traversal")
+    if unmount_timeout <= 0:
+      raise StorageError("unmount timeout must be positive")
+
+    self.requested_mount_parent = requested_mount.parent
+    self.mount_parent = self.requested_mount_parent
+    self.mount = requested_mount
+    self.pidfile = self.requested_mount_parent.with_suffix(".pid")
+    self.unmount_timeout = unmount_timeout
+    self.command_runner = command_runner
+    self.mount_inspector = mount_inspector
+
+  def _resolved_managed_paths(self) -> tuple[Path, Path, Path]:
+    parent_metadata = self.requested_mount_parent.lstat()
+    if not stat.S_ISDIR(parent_metadata.st_mode) or stat.S_ISLNK(parent_metadata.st_mode):
+      raise StorageError("managed FUSE parent must be a real directory")
+    resolved_mount_parent = self.requested_mount_parent.resolve(strict=True)
+    if resolved_mount_parent == Path("/"):
+      raise StorageError("managed FUSE path must not be the filesystem root")
+    resolved_mount = resolved_mount_parent / self.mount.name
+    resolved_pidfile = resolved_mount_parent.with_suffix(".pid")
+
+    snapshot = self.snapshot_builder.snapshot
+    source = self.snapshot_builder.source
+    if (
+      resolved_mount_parent == snapshot
+      or resolved_mount_parent.is_relative_to(snapshot)
+      or snapshot.is_relative_to(resolved_mount_parent)
+      or resolved_mount_parent == source
+      or resolved_mount_parent.is_relative_to(source)
+      or source.is_relative_to(resolved_mount_parent)
+    ):
+      raise StorageError("managed FUSE, snapshot, and source paths must not contain each other")
+    return resolved_mount_parent, resolved_mount, resolved_pidfile
+
+  @staticmethod
+  def _validate_optional_regular_file(path: Path, description: str) -> None:
+    try:
+      metadata = path.lstat()
+    except FileNotFoundError:
+      return
+    if not stat.S_ISREG(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+      raise StorageError(f"{description} is unsafe")
+
+  def _mounted_filesystems(self) -> tuple[tuple[str, str], ...]:
+    try:
+      return self.mount_inspector(self.requested_mount_parent)
+    except OSError as exc:
+      raise StorageError(f"cannot inspect stale nbdfuse mount state: {exc}") from exc
+
+  def _validate_managed_mount(self, entries: tuple[tuple[str, str], ...]) -> None:
+    if len(entries) != 1:
+      raise StorageError("refusing stacked filesystems at managed nbdfuse mountpoint")
+    filesystem_type, source = entries[0]
+    if filesystem_type != "fuse.nbdfuse" or source != "nbdfuse":
+      raise StorageError(f"refusing to detach foreign filesystem {filesystem_type}:{source}")
+
+  def _detach_stale_fuse(self) -> None:
+    entries = self._mounted_filesystems()
+    if not entries:
+      return
+    self._validate_managed_mount(entries)
+    try:
+      result = self.command_runner(
+        ["/usr/bin/fusermount3", "-uz", str(self.requested_mount_parent)],
+        check=False,
+        timeout=self.unmount_timeout,
+      )
+    except subprocess.TimeoutExpired as exc:
+      raise StorageError("timed out detaching stale nbdfuse mount") from exc
+    if getattr(result, "returncode", 0) != 0:
+      raise StorageError(f"stale nbdfuse detach failed with status {result.returncode}")
+    if self._mounted_filesystems():
+      raise StorageError("stale nbdfuse mount remains attached")
+
+  def cleanup(self) -> None:
+    # Snapshot validation runs before any removal. In particular, a foreign
+    # mount or symlink beneath the managed snapshot makes the whole operation
+    # fail closed without unlinking a single snapshot entry.
+    self.snapshot_builder.validate_cleanup_target()
+    self._validate_optional_regular_file(self.pidfile, "nbdfuse pidfile")
+    # Read /proc/self/mountinfo before touching the mountpoint itself. A dead
+    # FUSE mount can make lstat()/resolve() fail with ENOTCONN, but its exact
+    # target and filesystem identity remain available in the kernel table.
+    self._detach_stale_fuse()
+    # A FUSE mount hides its underlying output artifact. Validate it only
+    # after detaching, then remove exactly that file and the adjacent pidfile.
+    _mount_parent, resolved_mount, resolved_pidfile = self._resolved_managed_paths()
+    self._validate_optional_regular_file(resolved_mount, "nbdfuse output path")
+    self._validate_optional_regular_file(resolved_pidfile, "nbdfuse pidfile")
+    for artifact in (resolved_mount, resolved_pidfile):
+      try:
+        artifact.unlink()
+      except FileNotFoundError:
+        pass
+    self.snapshot_builder.cleanup()
+
+
+def _build_parser() -> argparse.ArgumentParser:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument("--source", default="/data/media/0/realdata")
+  parser.add_argument("--snapshot", default="/data/tmp/usb-storage-snapshot")
+  parser.add_argument("--mount", default="/run/usb-storage/footage.img")
+  parser.add_argument("--unmount-timeout", type=float, default=5.0)
+  return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+  arguments = _build_parser().parse_args(argv)
+  try:
+    StoppedStorageCleanup(
+      source=arguments.source,
+      snapshot=arguments.snapshot,
+      mount=arguments.mount,
+      unmount_timeout=arguments.unmount_timeout,
+    ).cleanup()
+  except (OSError, StorageError) as exc:
+    print(f"USB storage post-stop cleanup failed safely: {exc}", file=sys.stderr)
+    return 1
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/userspace/root/usr/comma/cleanup_usb_storage.sh
+++ b/userspace/root/usr/comma/cleanup_usb_storage.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+GADGET_HELPER="${USB_GADGET_HELPER:-/usr/comma/usb_gadget.sh}"
+CLEANUP_BIN="${USB_STORAGE_CLEANUP_BIN:-/usr/comma/cleanup_usb_storage.py}"
+
+fail_unbound() {
+  "$GADGET_HELPER" unbind >/dev/null 2>&1 || true
+}
+
+# ExecStopPost runs after systemd has killed the service cgroup, so nbdfuse and
+# nbdkit can no longer race this recovery. Release only our validated LUN
+# before detaching FUSE or dropping the snapshot's hard links.
+if ! "$GADGET_HELPER" prepare-storage-post-stop; then
+  fail_unbound
+  exit 1
+fi
+if ! "$CLEANUP_BIN"; then
+  fail_unbound
+  exit 1
+fi
+
+# A forced stop leaves the gadget unbound while cleanup runs. Reconstruct the
+# complete requested personality; never raw-bind potentially partial state.
+if ! "$GADGET_HELPER" ensure-requested-personality; then
+  fail_unbound
+  exit 1
+fi

--- a/userspace/root/usr/comma/set_adb.sh
+++ b/userspace/root/usr/comma/set_adb.sh
@@ -12,6 +12,7 @@ else
   echo "Disabling ADB"
 fi
 
-# usb_gadget.sh is the sole owner of configfs setup. NCM and read-only storage
-# remain available regardless of the ADB param; only FunctionFS ADB is gated.
+# usb_gadget.sh is the sole owner of configfs setup. The ADB personality keeps
+# its legacy NCM and FunctionFS interfaces; ADB-off exposes storage only under
+# a distinct owner-approved USB identity.
 exec "$GADGET_HELPER" configure "$adb_enabled"

--- a/userspace/root/usr/comma/set_adb.sh
+++ b/userspace/root/usr/comma/set_adb.sh
@@ -1,72 +1,17 @@
 #!/bin/bash
+set -euo pipefail
 
-setup() {
-  # Check if /config is already mounted
-  if ! mountpoint -q /config; then
-    sudo mount -t configfs none /config
-  else
-    echo "/config is already mounted."
-  fi
+ADB_PARAM="${USB_GADGET_ADB_PARAM:-/data/params/d/AdbEnabled}"
+GADGET_HELPER="${USB_GADGET_HELPER:-$(dirname "${BASH_SOURCE[0]}")/usb_gadget.sh}"
 
-  # Create USB gadget directory structure
-  sudo mkdir -p /config/usb_gadget/g1
-  cd /config/usb_gadget/g1
-  sudo mkdir -p strings/0x409
-  sudo mkdir -p configs/c.1/strings/0x409
-  sudo mkdir -p functions/ncm.0
-
-  # Set Vendor and Product ID
-  echo 0x04D8 | sudo tee idVendor
-  echo 0x1234 | sudo tee idProduct
-
-  # Set strings
-  echo "$(cat /proc/cmdline | sed -e 's/^.*androidboot.serialno=//' -e 's/ .*$//')" | sudo tee strings/0x409/serialnumber
-  echo "comma.ai" | sudo tee strings/0x409/manufacturer
-  echo "Linux USB Gadget" | sudo tee strings/0x409/product
-  echo 250 | sudo tee configs/c.1/MaxPower
-
-  # Create ADB function
-  sudo mkdir -p functions/ffs.adb
-  sudo mkdir -p /dev/usb-ffs/adb
-  if ! mountpoint -q /dev/usb-ffs/adb; then
-    sudo mount -t functionfs adb /dev/usb-ffs/adb
-  else
-    echo "/dev/usb-ffs/adb is already mounted"
-  fi
-
-  # Link both functions to configuration
-  echo "NCM+ADB" | sudo tee configs/c.1/strings/0x409/configuration
-  sudo rm -f configs/c.1/ncm.0
-  sudo rm -f configs/c.1/ffs.adb
-  sudo ln -s functions/ncm.0 configs/c.1/
-  sudo ln -s functions/ffs.adb configs/c.1/
-}
-
-start() {
-  setprop service.adb.tcp.port -1
-
-  cd /config/usb_gadget/g1
-  echo "a600000.dwc3" | sudo tee UDC
-}
-
-stop() {
-  if [ -d "/config/usb_gadget/g1" ]; then
-    cd /config/usb_gadget/g1
-    echo "" | sudo tee UDC
-  fi
-}
-
-ADB_PARAM="/data/params/d/AdbEnabled"
-if [ -f "$ADB_PARAM" ] && [ "$(< $ADB_PARAM)" == "1" ]; then
+adb_enabled=0
+if [[ -r "$ADB_PARAM" ]] && [[ "$(< "$ADB_PARAM")" == "1" ]]; then
+  adb_enabled=1
   echo "Enabling ADB"
-
-  setup
-  systemctl start adbd
-  sleep 1  # adbd does some setup before we can enable the gadget
-  start
 else
   echo "Disabling ADB"
-
-  systemctl stop adbd
-  stop
 fi
+
+# usb_gadget.sh is the sole owner of configfs setup. NCM and read-only storage
+# remain available regardless of the ADB param; only FunctionFS ADB is gated.
+exec "$GADGET_HELPER" configure "$adb_enabled"

--- a/userspace/root/usr/comma/stop_usb_storage.sh
+++ b/userspace/root/usr/comma/stop_usb_storage.sh
@@ -43,6 +43,7 @@ if process_is_alive; then
   done
 fi
 
-# This is deliberately last. If graceful cleanup failed, systemd will kill the
-# remaining FUSE/NBD cgroup only after the host-facing gadget is disconnected.
-"$GADGET_HELPER" unbind
+# This is deliberately last. A clean empty LUN keeps the other USB functions
+# bound (and restores a fallback unbind); attached/unsafe media leaves the
+# gadget disconnected before systemd kills the remaining FUSE/NBD cgroup.
+"$GADGET_HELPER" finalize-storage-stop

--- a/userspace/root/usr/comma/stop_usb_storage.sh
+++ b/userspace/root/usr/comma/stop_usb_storage.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euo pipefail
+
+GADGET_HELPER="${USB_GADGET_HELPER:-/usr/comma/usb_gadget.sh}"
+SLEEP_BIN="${USB_STORAGE_SLEEP_BIN:-sleep}"
+STOP_ATTEMPTS="${USB_STORAGE_STOP_ATTEMPTS:-300}"
+KILL_ATTEMPTS="${USB_STORAGE_KILL_ATTEMPTS:-20}"
+POLL_INTERVAL="${USB_STORAGE_STOP_INTERVAL:-0.1}"
+
+main_pid="${1:-}"
+if [[ ! "$main_pid" =~ ^[1-9][0-9]*$ ]]; then
+  echo "usage: $0 MAINPID" >&2
+  "$GADGET_HELPER" unbind
+  exit 2
+fi
+if [[ ! "$STOP_ATTEMPTS" =~ ^[1-9][0-9]*$ ]] || [[ ! "$KILL_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "USB storage stop attempts must be positive integers" >&2
+  "$GADGET_HELPER" unbind
+  exit 2
+fi
+
+process_is_alive() {
+  kill -0 "$main_pid" 2>/dev/null
+}
+
+# systemd runs ExecStop before applying KillSignal. Signal the manager first so
+# graceful teardown observes stop_event and cannot choose to rebind. If it was
+# already inside a rebind-capable teardown, wait for that operation to finish.
+if process_is_alive; then
+  kill -TERM "$main_pid" 2>/dev/null || true
+fi
+for ((attempt = 1; attempt <= STOP_ATTEMPTS; attempt++)); do
+  process_is_alive || break
+  "$SLEEP_BIN" "$POLL_INTERVAL"
+done
+
+if process_is_alive; then
+  echo "USB storage manager did not stop gracefully; forcing main-process exit" >&2
+  kill -KILL "$main_pid" 2>/dev/null || true
+  for ((attempt = 1; attempt <= KILL_ATTEMPTS; attempt++)); do
+    process_is_alive || break
+    "$SLEEP_BIN" "$POLL_INTERVAL"
+  done
+fi
+
+# This is deliberately last. If graceful cleanup failed, systemd will kill the
+# remaining FUSE/NBD cgroup only after the host-facing gadget is disconnected.
+"$GADGET_HELPER" unbind

--- a/userspace/root/usr/comma/tmpfiles.conf
+++ b/userspace/root/usr/comma/tmpfiles.conf
@@ -21,3 +21,6 @@ d /var/spool 0755 - - -
 d /var/spool/cron/atjobs 0755 - - -
 
 d /var/cache/pollinate 0755 pollinate daemon -
+
+# Serialize all configfs USB gadget owners before comma code starts.
+f /run/lock/comma-usb-gadget.lock 0600 root root -

--- a/userspace/root/usr/comma/usb_gadget.sh
+++ b/userspace/root/usr/comma/usb_gadget.sh
@@ -197,8 +197,17 @@ validate_managed_storage_personality() {
   local adb_enabled=0
   local configured_function
   local expected_configuration="Storage"
+  local expected_backing_file="$MANAGED_BACKING_FILE"
   local expected_product="$STORAGE_ONLY_PID"
   local expected_vendor="$STORAGE_ONLY_VID"
+
+  if (($#)); then
+    expected_backing_file="$1"
+  fi
+  if [[ -n "$expected_backing_file" && "$expected_backing_file" != "$MANAGED_BACKING_FILE" ]]; then
+    echo "refusing invalid managed USB storage backing-file expectation" >&2
+    return 1
+  fi
 
   validate_managed_storage_topology || return 1
 
@@ -229,7 +238,7 @@ validate_managed_storage_personality() {
      [[ ! -r "$FUNCTION_ROOT/mass_storage.0/lun.0/ro" ]] || \
      [[ ! -r "$FUNCTION_ROOT/mass_storage.0/lun.0/removable" ]] || \
      [[ ! -r "$FUNCTION_ROOT/mass_storage.0/stall" ]] || \
-     [[ "$(< "$FUNCTION_ROOT/mass_storage.0/lun.0/file")" != "$MANAGED_BACKING_FILE" ]] || \
+     [[ "$(< "$FUNCTION_ROOT/mass_storage.0/lun.0/file")" != "$expected_backing_file" ]] || \
      [[ "$(< "$FUNCTION_ROOT/mass_storage.0/lun.0/ro")" != "1" ]] || \
      [[ "$(< "$FUNCTION_ROOT/mass_storage.0/lun.0/removable")" != "1" ]] || \
      [[ "$(< "$FUNCTION_ROOT/mass_storage.0/stall")" != "1" ]] || \
@@ -250,7 +259,8 @@ validate_managed_storage_personality() {
 
   # Reject every unrecognized function, including functions another process
   # may have added. Descriptor directories are not symbolic links.
-  for configured_function in "$CONFIG_ROOT"/*; do
+  for configured_function in "$CONFIG_ROOT"/* "$CONFIG_ROOT"/.[!.]* "$CONFIG_ROOT"/..?*; do
+    [[ -e "$configured_function" ]] || [[ -L "$configured_function" ]] || continue
     [[ -L "$configured_function" ]] || continue
     case "${configured_function##*/}" in
       mass_storage.0) ;;
@@ -298,6 +308,49 @@ reenumerate_managed_storage() {
     return 1
   fi
   bind_gadget
+}
+
+prepare_storage_post_stop() {
+  local lun_root="$FUNCTION_ROOT/mass_storage.0/lun.0"
+  local backing_file=""
+
+  # ExecStopPost runs after the service cgroup is dead. Validate the complete
+  # LUN ownership boundary and accept only an empty LUN or this service's exact
+  # backing path. Descriptor and function-link state is deliberately irrelevant
+  # after unbinding: it must not prevent releasing a safe managed snapshot.
+  # Foreign/unsafe media is preserved for diagnosis and left disconnected.
+  if ! validate_managed_storage_topology || \
+     [[ ! -f "$lun_root/file" ]] || [[ -L "$lun_root/file" ]] || \
+     [[ ! -f "$lun_root/ro" ]] || [[ -L "$lun_root/ro" ]] || \
+     [[ ! -f "$lun_root/removable" ]] || [[ -L "$lun_root/removable" ]] || \
+     [[ ! -f "$FUNCTION_ROOT/mass_storage.0/stall" ]] || [[ -L "$FUNCTION_ROOT/mass_storage.0/stall" ]]; then
+    unbind_gadget
+    echo "USB storage post-stop LUN state is unavailable or unsafe; leaving gadget unbound" >&2
+    return 1
+  fi
+  backing_file="$(< "$lun_root/file")"
+  if [[ "$(< "$lun_root/ro")" != "1" ]] || [[ "$(< "$lun_root/removable")" != "1" ]] || \
+     [[ "$(< "$FUNCTION_ROOT/mass_storage.0/stall")" != "1" ]]; then
+    unbind_gadget
+    echo "USB storage post-stop LUN policy is unsafe; leaving gadget unbound" >&2
+    return 1
+  fi
+  if [[ -n "$backing_file" && "$backing_file" != "$MANAGED_BACKING_FILE" ]]; then
+    unbind_gadget
+    echo "refusing to clear a foreign USB mass-storage LUN after stop" >&2
+    return 1
+  fi
+
+  if [[ -n "$backing_file" ]]; then
+    unbind_gadget
+    clear_lun_file "$lun_root/file"
+  elif ! validate_managed_storage_personality ""; then
+    # Preserve a zero-bounce clean stop only when the currently bound empty
+    # personality is complete. Descriptor/link/PID drift must not block stale
+    # snapshot cleanup, but it must be disconnected before cleanup and rebuilt
+    # through the safe configuration path afterward.
+    unbind_gadget
+  fi
 }
 
 finalize_storage_stop() {
@@ -603,6 +656,9 @@ case "${1:-}" in
   reenumerate-managed-storage)
     reenumerate_managed_storage
     ;;
+  prepare-storage-post-stop)
+    prepare_storage_post_stop
+    ;;
   finalize-storage-stop)
     finalize_storage_stop
     ;;
@@ -610,7 +666,7 @@ case "${1:-}" in
     prepare_storage_start
     ;;
   *)
-    echo "usage: $0 {configure <0|1>|bind|unbind|ensure-requested-personality|reenumerate-managed-storage|finalize-storage-stop|prepare-storage-start}" >&2
+    echo "usage: $0 {configure <0|1>|bind|unbind|ensure-requested-personality|reenumerate-managed-storage|prepare-storage-post-stop|finalize-storage-stop|prepare-storage-start}" >&2
     exit 2
     ;;
 esac

--- a/userspace/root/usr/comma/usb_gadget.sh
+++ b/userspace/root/usr/comma/usb_gadget.sh
@@ -12,6 +12,14 @@ FFS_ADB_ROOT="${USB_GADGET_FFS_ADB_ROOT:-/dev/usb-ffs/adb}"
 LOCK_FILE="${USB_GADGET_LOCK_FILE:-/run/lock/comma-usb-gadget.lock}"
 UDC_NAME="${USB_GADGET_UDC:-a600000.dwc3}"
 MANAGED_BACKING_FILE="${USB_GADGET_MANAGED_BACKING_FILE:-/run/usb-storage/footage.img}"
+ADB_PARAM="${USB_GADGET_ADB_PARAM:-/data/params/d/AdbEnabled}"
+# ADB-off is a distinct USB personality: mass storage at MI_00, without NCM or
+# a disabled-placeholder interface.  It requires a product ID assigned by the
+# VID owner so Windows cannot reuse the legacy 0x1234/MI_02 ADB driver binding.
+# These intentionally have no production defaults until comma approves the
+# identity; it may be allocated under comma's own VID or the legacy VID.
+STORAGE_ONLY_VID="${USB_GADGET_STORAGE_ONLY_VID:-}"
+STORAGE_ONLY_PID="${USB_GADGET_STORAGE_ONLY_PID:-}"
 
 MOUNTPOINT_BIN="${USB_GADGET_MOUNTPOINT_BIN:-mountpoint}"
 MOUNT_BIN="${USB_GADGET_MOUNT_BIN:-mount}"
@@ -72,6 +80,85 @@ bind_gadget() {
   write_attr "$UDC_NAME" "$GADGET_ROOT/UDC"
 }
 
+ensure_requested_personality() {
+  local current_udc=""
+  local adb_enabled=0
+
+  current_udc="$(< "$GADGET_ROOT/UDC")"
+  if [[ -n "$current_udc" ]]; then
+    return 0
+  fi
+  if [[ -r "$ADB_PARAM" ]] && [[ "$(< "$ADB_PARAM")" == "1" ]]; then
+    adb_enabled=1
+  fi
+  configure_gadget "$adb_enabled"
+}
+
+finalize_storage_stop() {
+  local lun_root="$FUNCTION_ROOT/mass_storage.0/lun.0"
+  local backing_file=""
+
+  # The manager is already dead when this runs, so its configfs operations
+  # cannot race this final decision. Preserve ADB/NCM after a clean stop, but
+  # disconnect the whole gadget before systemd kills any backing processes if
+  # media is still attached or the LUN policy cannot be verified.
+  if [[ ! -r "$lun_root/file" || ! -r "$lun_root/ro" || ! -r "$lun_root/removable" ]]; then
+    unbind_gadget
+    echo "USB storage LUN state is unavailable; leaving gadget unbound" >&2
+    return 1
+  fi
+  backing_file="$(< "$lun_root/file")"
+  if [[ -n "$backing_file" ]] || [[ "$(< "$lun_root/ro")" != "1" ]] || [[ "$(< "$lun_root/removable")" != "1" ]]; then
+    unbind_gadget
+    if [[ -n "$backing_file" ]]; then
+      echo "USB storage media remains attached; leaving gadget unbound" >&2
+    else
+      echo "USB storage LUN policy is unsafe; leaving gadget unbound" >&2
+    fi
+    return 0
+  fi
+
+  # A PREVENT-MEDIUM-REMOVAL fallback and a failed descriptor transition both
+  # leave an empty UDC. Reconstruct the full requested personality instead of
+  # blindly binding partial links/descriptors. This fails unbound when the
+  # storage-only identity has not been approved.
+  ensure_requested_personality
+}
+
+prepare_storage_start() {
+  local lun_root="$FUNCTION_ROOT/mass_storage.0/lun.0"
+  local backing_file=""
+
+  # This runs before any stale FUSE recovery. Configfs must stop referencing
+  # the old virtual disk first, or a lazy unmount could invalidate live host
+  # I/O. Only this service's exact backing path may be released.
+  if [[ ! -r "$lun_root/file" || ! -r "$lun_root/ro" || ! -r "$lun_root/removable" ]]; then
+    unbind_gadget
+    echo "USB storage LUN state is unavailable; leaving gadget unbound" >&2
+    return 1
+  fi
+  backing_file="$(< "$lun_root/file")"
+  if [[ "$(< "$lun_root/ro")" != "1" ]] || [[ "$(< "$lun_root/removable")" != "1" ]]; then
+    unbind_gadget
+    echo "USB storage LUN policy is unsafe; leaving gadget unbound" >&2
+    return 1
+  fi
+  if [[ -n "$backing_file" && "$backing_file" != "$MANAGED_BACKING_FILE" ]]; then
+    unbind_gadget
+    echo "refusing to clear a foreign USB mass-storage LUN" >&2
+    return 1
+  fi
+  if [[ -n "$backing_file" ]]; then
+    unbind_gadget
+    clear_lun_file "$lun_root/file" || return 1
+  fi
+
+  # A failed asynchronous personality transition and a legitimate fallback
+  # unbind are indistinguishable here. Reconstruct the complete requested
+  # personality instead of raw-binding potentially partial descriptors.
+  ensure_requested_personality
+}
+
 remove_owned_links() {
   local link
   for link in ncm.0 ffs.adb mass_storage.0; do
@@ -117,7 +204,7 @@ clear_lun_file() {
   local attempt
 
   for ((attempt = 1; attempt <= CLEAR_ATTEMPTS; attempt++)); do
-    if write_attr "" "$file" 2>/dev/null; then
+    if write_attr "" "$file" 2>/dev/null && [[ "$(< "$file")" == "" ]]; then
       return 0
     fi
     if ((attempt < CLEAR_ATTEMPTS)); then
@@ -132,6 +219,8 @@ configure_gadget() {
   local adb_enabled="$1"
   local backing_file
   local mass_storage_created=0
+  local vendor_id="0x04D8"
+  local product_id="0x1234"
 
   RESTORE_BINDING=0
   RESTORE_HAD_ADB=0
@@ -142,6 +231,22 @@ configure_gadget() {
   if [[ "$adb_enabled" != "0" && "$adb_enabled" != "1" ]]; then
     echo "usage: $0 configure <0|1>" >&2
     return 2
+  fi
+  if [[ "$adb_enabled" == "0" ]]; then
+    if [[ ! "$STORAGE_ONLY_VID" =~ ^0[xX][0-9a-fA-F]{4}$ ]] || \
+       [[ ! "$STORAGE_ONLY_PID" =~ ^0[xX][0-9a-fA-F]{4}$ ]] || \
+       [[ "$STORAGE_ONLY_VID" =~ ^0[xX]04[dD]8$ && "$STORAGE_ONLY_PID" =~ ^0[xX]1234$ ]]; then
+      # AdbEnabled=0 must fail closed even before a storage-only identity is
+      # allocated. Otherwise a previously bound debug personality and adbd
+      # would remain reachable after the user disabled them.
+      ensure_configfs
+      unbind_gadget
+      "$SYSTEMCTL_BIN" stop adbd
+      echo "ADB-off storage requires a distinct owner-approved USB VID/PID" >&2
+      return 1
+    fi
+    vendor_id="$STORAGE_ONLY_VID"
+    product_id="$STORAGE_ONLY_PID"
   fi
 
   ensure_configfs
@@ -178,8 +283,13 @@ configure_gadget() {
   # as while the UDC is unbound (stall returns EBUSY once linked).
   remove_owned_links
 
-  write_attr "0x04D8" "$GADGET_ROOT/idVendor"
-  write_attr "0x1234" "$GADGET_ROOT/idProduct"
+  # Descriptor and daemon changes below cannot be safely rolled back from only
+  # a link snapshot. Any later failure must therefore leave the gadget unbound
+  # instead of mixing the old functions with a new VID/PID personality.
+  RESTORE_BINDING=0
+
+  write_attr "$vendor_id" "$GADGET_ROOT/idVendor"
+  write_attr "$product_id" "$GADGET_ROOT/idProduct"
   write_attr "$(read_serial)" "$GADGET_ROOT/strings/0x409/serialnumber"
   write_attr "comma.ai" "$GADGET_ROOT/strings/0x409/manufacturer"
   write_attr "Linux USB Gadget" "$GADGET_ROOT/strings/0x409/product"
@@ -208,17 +318,15 @@ configure_gadget() {
     if ! clear_lun_file "$FUNCTION_ROOT/mass_storage.0/lun.0/file"; then
       exit 1
     fi
-    RESTORE_BINDING=1
   fi
   write_attr "1" "$FUNCTION_ROOT/mass_storage.0/lun.0/ro"
   write_attr "1" "$FUNCTION_ROOT/mass_storage.0/lun.0/removable"
   write_attr "1" "$FUNCTION_ROOT/mass_storage.0/stall"
 
-  # Keep the pre-existing NCM and ADB interface numbers stable for hosts that
-  # cache composite-device bindings. Mass storage is always appended last.
-  link_function ncm.0
-
   if [[ "$adb_enabled" == "1" ]]; then
+    # Keep the pre-existing NCM and ADB interface numbers stable for hosts that
+    # cache composite-device bindings. Mass storage is appended as MI_03.
+    link_function ncm.0
     mkdir -p "$FUNCTION_ROOT/ffs.adb" "$FFS_ADB_ROOT"
     if [[ "$SKIP_MOUNTS" != "1" ]] && ! "$MOUNTPOINT_BIN" -q "$FFS_ADB_ROOT"; then
       "$MOUNT_BIN" -t functionfs adb "$FFS_ADB_ROOT"
@@ -235,7 +343,7 @@ configure_gadget() {
     write_attr "NCM+ADB+Storage" "$CONFIG_ROOT/strings/0x409/configuration"
   else
     "$SYSTEMCTL_BIN" stop adbd
-    write_attr "NCM+Storage" "$CONFIG_ROOT/strings/0x409/configuration"
+    write_attr "Storage" "$CONFIG_ROOT/strings/0x409/configuration"
   fi
 
   bind_gadget
@@ -275,8 +383,14 @@ case "${1:-}" in
   unbind)
     unbind_gadget
     ;;
+  finalize-storage-stop)
+    finalize_storage_stop
+    ;;
+  prepare-storage-start)
+    prepare_storage_start
+    ;;
   *)
-    echo "usage: $0 {configure <0|1>|bind|unbind}" >&2
+    echo "usage: $0 {configure <0|1>|bind|unbind|finalize-storage-stop|prepare-storage-start}" >&2
     exit 2
     ;;
 esac

--- a/userspace/root/usr/comma/usb_gadget.sh
+++ b/userspace/root/usr/comma/usb_gadget.sh
@@ -1,0 +1,282 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+# Environment overrides make the configfs operations testable without a USB
+# controller. Production callers use all of the defaults below.
+CONFIGFS_ROOT="${USB_GADGET_CONFIGFS_ROOT:-/config}"
+GADGET_NAME="${USB_GADGET_NAME:-g1}"
+GADGET_ROOT="$CONFIGFS_ROOT/usb_gadget/$GADGET_NAME"
+CONFIG_ROOT="$GADGET_ROOT/configs/c.1"
+FUNCTION_ROOT="$GADGET_ROOT/functions"
+FFS_ADB_ROOT="${USB_GADGET_FFS_ADB_ROOT:-/dev/usb-ffs/adb}"
+LOCK_FILE="${USB_GADGET_LOCK_FILE:-/run/lock/comma-usb-gadget.lock}"
+UDC_NAME="${USB_GADGET_UDC:-a600000.dwc3}"
+MANAGED_BACKING_FILE="${USB_GADGET_MANAGED_BACKING_FILE:-/run/usb-storage/footage.img}"
+
+MOUNTPOINT_BIN="${USB_GADGET_MOUNTPOINT_BIN:-mountpoint}"
+MOUNT_BIN="${USB_GADGET_MOUNT_BIN:-mount}"
+FLOCK_BIN="${USB_GADGET_FLOCK_BIN:-flock}"
+SYSTEMCTL_BIN="${USB_GADGET_SYSTEMCTL_BIN:-systemctl}"
+SETPROP_BIN="${USB_GADGET_SETPROP_BIN:-setprop}"
+SLEEP_BIN="${USB_GADGET_SLEEP_BIN:-sleep}"
+LN_BIN="${USB_GADGET_LN_BIN:-ln}"
+SKIP_MOUNTS="${USB_GADGET_SKIP_MOUNTS:-0}"
+CLEAR_ATTEMPTS="${USB_GADGET_CLEAR_ATTEMPTS:-50}"
+CLEAR_INTERVAL="${USB_GADGET_CLEAR_INTERVAL:-0.1}"
+RESTORE_BINDING=0
+RESTORE_HAD_ADB=0
+RESTORE_HAD_MASS_STORAGE=0
+RESTORE_HAD_NCM=0
+RESTORE_PREVIOUS_UDC=""
+
+if [[ ! "$CLEAR_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "USB_GADGET_CLEAR_ATTEMPTS must be a positive integer" >&2
+  exit 2
+fi
+
+write_attr() {
+  local value="$1"
+  local path="$2"
+  printf '%s\n' "$value" > "$path"
+}
+
+ensure_configfs() {
+  mkdir -p "$CONFIGFS_ROOT"
+  if [[ "$SKIP_MOUNTS" != "1" ]] && ! "$MOUNTPOINT_BIN" -q "$CONFIGFS_ROOT"; then
+    "$MOUNT_BIN" -t configfs none "$CONFIGFS_ROOT"
+  fi
+}
+
+unbind_gadget() {
+  local current_udc=""
+  if [[ -r "$GADGET_ROOT/UDC" ]]; then
+    current_udc="$(< "$GADGET_ROOT/UDC")"
+  fi
+  if [[ -n "$current_udc" ]]; then
+    write_attr "" "$GADGET_ROOT/UDC"
+  fi
+}
+
+bind_gadget() {
+  local current_udc=""
+  if [[ -r "$GADGET_ROOT/UDC" ]]; then
+    current_udc="$(< "$GADGET_ROOT/UDC")"
+  fi
+  if [[ "$current_udc" == "$UDC_NAME" ]]; then
+    return 0
+  fi
+  if [[ -n "$current_udc" ]]; then
+    echo "USB gadget is already bound to $current_udc" >&2
+    return 1
+  fi
+  write_attr "$UDC_NAME" "$GADGET_ROOT/UDC"
+}
+
+remove_owned_links() {
+  local link
+  for link in ncm.0 ffs.adb mass_storage.0; do
+    if [[ -L "$CONFIG_ROOT/$link" ]]; then
+      unlink "$CONFIG_ROOT/$link"
+    fi
+  done
+}
+
+link_function() {
+  local name="$1"
+  "$LN_BIN" -s "$FUNCTION_ROOT/$name" "$CONFIG_ROOT/$name"
+}
+
+restore_gadget_on_exit() {
+  local status=$?
+  trap - EXIT
+
+  if ((RESTORE_BINDING)); then
+    remove_owned_links || true
+    if ((RESTORE_HAD_NCM)); then link_function ncm.0 || true; fi
+    if ((RESTORE_HAD_ADB)); then link_function ffs.adb || true; fi
+    if ((RESTORE_HAD_MASS_STORAGE)); then link_function mass_storage.0 || true; fi
+    if [[ -n "$RESTORE_PREVIOUS_UDC" ]]; then
+      write_attr "$RESTORE_PREVIOUS_UDC" "$GADGET_ROOT/UDC" || true
+    fi
+  fi
+  exit "$status"
+}
+
+read_serial() {
+  local serial="${USB_GADGET_SERIAL:-}"
+  local cmdline="${USB_GADGET_CMDLINE:-/proc/cmdline}"
+
+  if [[ -z "$serial" ]] && [[ -r "$cmdline" ]]; then
+    serial="$(sed -n 's/.*androidboot.serialno=\([^ ]*\).*/\1/p' "$cmdline")"
+  fi
+  printf '%s' "${serial:-unknown}"
+}
+
+clear_lun_file() {
+  local file="$1"
+  local attempt
+
+  for ((attempt = 1; attempt <= CLEAR_ATTEMPTS; attempt++)); do
+    if write_attr "" "$file" 2>/dev/null; then
+      return 0
+    fi
+    if ((attempt < CLEAR_ATTEMPTS)); then
+      "$SLEEP_BIN" "$CLEAR_INTERVAL"
+    fi
+  done
+  echo "timed out clearing USB mass-storage LUN after UDC unbind" >&2
+  return 1
+}
+
+configure_gadget() {
+  local adb_enabled="$1"
+  local backing_file
+  local mass_storage_created=0
+
+  RESTORE_BINDING=0
+  RESTORE_HAD_ADB=0
+  RESTORE_HAD_MASS_STORAGE=0
+  RESTORE_HAD_NCM=0
+  RESTORE_PREVIOUS_UDC=""
+
+  if [[ "$adb_enabled" != "0" && "$adb_enabled" != "1" ]]; then
+    echo "usage: $0 configure <0|1>" >&2
+    return 2
+  fi
+
+  ensure_configfs
+  mkdir -p "$GADGET_ROOT"
+
+  if [[ -r "$GADGET_ROOT/UDC" ]]; then
+    RESTORE_PREVIOUS_UDC="$(< "$GADGET_ROOT/UDC")"
+  fi
+  if [[ -L "$CONFIG_ROOT/ncm.0" ]]; then RESTORE_HAD_NCM=1; fi
+  if [[ -L "$CONFIG_ROOT/mass_storage.0" ]]; then RESTORE_HAD_MASS_STORAGE=1; fi
+  if [[ -L "$CONFIG_ROOT/ffs.adb" ]]; then RESTORE_HAD_ADB=1; fi
+
+  # USB gadget functions and links cannot be changed while the UDC is bound.
+  # If setup fails partway through, restore the previous usable binding on a
+  # best-effort basis rather than leaving USB disconnected.
+  unbind_gadget
+  RESTORE_BINDING=1
+  trap restore_gadget_on_exit EXIT
+
+  mkdir -p \
+    "$GADGET_ROOT/strings/0x409" \
+    "$CONFIG_ROOT/strings/0x409" \
+    "$FUNCTION_ROOT/ncm.0"
+
+  if [[ ! -d "$FUNCTION_ROOT/mass_storage.0" ]]; then
+    mkdir -p "$FUNCTION_ROOT/mass_storage.0"
+    mass_storage_created=1
+  fi
+  # lun.0 is created by configfs on-device; mkdir is also useful for a fake
+  # configfs tree in tests.
+  mkdir -p "$FUNCTION_ROOT/mass_storage.0/lun.0"
+
+  # Function attributes must be changed while the function is unlinked as well
+  # as while the UDC is unbound (stall returns EBUSY once linked).
+  remove_owned_links
+
+  write_attr "0x04D8" "$GADGET_ROOT/idVendor"
+  write_attr "0x1234" "$GADGET_ROOT/idProduct"
+  write_attr "$(read_serial)" "$GADGET_ROOT/strings/0x409/serialnumber"
+  write_attr "comma.ai" "$GADGET_ROOT/strings/0x409/manufacturer"
+  write_attr "Linux USB Gadget" "$GADGET_ROOT/strings/0x409/product"
+  write_attr "250" "$CONFIG_ROOT/MaxPower"
+
+  # Hosts must never receive /data or another live filesystem. Every gadget
+  # reconfiguration ejects stale media before relinking; the manager may later
+  # hot-insert only its generated image into this removable, read-only LUN.
+  if ((mass_storage_created)) || [[ ! -e "$FUNCTION_ROOT/mass_storage.0/lun.0/file" ]]; then
+    : > "$FUNCTION_ROOT/mass_storage.0/lun.0/file"
+  fi
+  backing_file="$(< "$FUNCTION_ROOT/mass_storage.0/lun.0/file")"
+  if [[ -n "$backing_file" ]]; then
+    # From this point until the stale media is gone, any error must leave the
+    # UDC unbound. Rebinding a dead FUSE target or unsafe LUN is never valid.
+    RESTORE_BINDING=0
+    if [[ "$backing_file" != "$MANAGED_BACKING_FILE" ]]; then
+      echo "refusing to clear a foreign USB mass-storage LUN" >&2
+      exit 1
+    fi
+    if [[ "$(< "$FUNCTION_ROOT/mass_storage.0/lun.0/ro")" != "1" ]] || \
+       [[ "$(< "$FUNCTION_ROOT/mass_storage.0/lun.0/removable")" != "1" ]]; then
+      echo "refusing to reconfigure an attached writable or fixed USB LUN" >&2
+      exit 1
+    fi
+    if ! clear_lun_file "$FUNCTION_ROOT/mass_storage.0/lun.0/file"; then
+      exit 1
+    fi
+    RESTORE_BINDING=1
+  fi
+  write_attr "1" "$FUNCTION_ROOT/mass_storage.0/lun.0/ro"
+  write_attr "1" "$FUNCTION_ROOT/mass_storage.0/lun.0/removable"
+  write_attr "1" "$FUNCTION_ROOT/mass_storage.0/stall"
+
+  # Keep the pre-existing NCM and ADB interface numbers stable for hosts that
+  # cache composite-device bindings. Mass storage is always appended last.
+  link_function ncm.0
+
+  if [[ "$adb_enabled" == "1" ]]; then
+    mkdir -p "$FUNCTION_ROOT/ffs.adb" "$FFS_ADB_ROOT"
+    if [[ "$SKIP_MOUNTS" != "1" ]] && ! "$MOUNTPOINT_BIN" -q "$FFS_ADB_ROOT"; then
+      "$MOUNT_BIN" -t functionfs adb "$FFS_ADB_ROOT"
+    fi
+
+    "$SETPROP_BIN" service.adb.tcp.port -1
+    "$SYSTEMCTL_BIN" start adbd
+    "$SLEEP_BIN" 1  # adbd must open FunctionFS endpoints before UDC binding
+    link_function ffs.adb
+  fi
+
+  link_function mass_storage.0
+  if [[ "$adb_enabled" == "1" ]]; then
+    write_attr "NCM+ADB+Storage" "$CONFIG_ROOT/strings/0x409/configuration"
+  else
+    "$SYSTEMCTL_BIN" stop adbd
+    write_attr "NCM+Storage" "$CONFIG_ROOT/strings/0x409/configuration"
+  fi
+
+  bind_gadget
+  RESTORE_BINDING=0
+  trap - EXIT
+}
+
+mkdir -p "$(dirname "$LOCK_FILE")"
+if [[ -L "$LOCK_FILE" ]]; then
+  echo "refusing symbolic-link USB gadget lock" >&2
+  exit 1
+fi
+if [[ ! -e "$LOCK_FILE" ]]; then
+  # noclobber makes first creation exclusive. Production pre-creates this
+  # root-owned file through tmpfiles before less-trusted services start.
+  if ! (umask 077; set -o noclobber; : > "$LOCK_FILE") 2>/dev/null; then
+    echo "failed safely creating USB gadget lock" >&2
+    exit 1
+  fi
+fi
+if [[ ! -f "$LOCK_FILE" ]] || [[ -L "$LOCK_FILE" ]]; then
+  echo "USB gadget lock is not a regular file" >&2
+  exit 1
+fi
+# Open without truncation. The root-owned file cannot be replaced by an
+# unprivileged process in the sticky /run/lock directory.
+exec 9<> "$LOCK_FILE"
+"$FLOCK_BIN" -x 9
+
+case "${1:-}" in
+  configure)
+    configure_gadget "${2:-}"
+    ;;
+  bind)
+    bind_gadget
+    ;;
+  unbind)
+    unbind_gadget
+    ;;
+  *)
+    echo "usage: $0 {configure <0|1>|bind|unbind}" >&2
+    exit 2
+    ;;
+esac

--- a/userspace/root/usr/comma/usb_gadget.sh
+++ b/userspace/root/usr/comma/usb_gadget.sh
@@ -94,6 +94,212 @@ ensure_requested_personality() {
   configure_gadget "$adb_enabled"
 }
 
+function_link_is_exact() {
+  local name="$1"
+  [[ -L "$CONFIG_ROOT/$name" ]] && [[ "$CONFIG_ROOT/$name" -ef "$FUNCTION_ROOT/$name" ]]
+}
+
+usb_id_is() {
+  local actual="$1"
+  local expected="$2"
+  [[ "$actual" =~ ^0[xX][0-9a-fA-F]{4}$ ]] || return 1
+  [[ "$expected" =~ ^0[xX][0-9a-fA-F]{4}$ ]] || return 1
+  # Configfs canonicalizes hexadecimal attributes to lowercase on-device.
+  # Compare validated numeric values so fake configfs and the kernel's
+  # readback spelling are both accepted without weakening identity checks.
+  ((actual == expected))
+}
+
+validate_single_configuration() {
+  local entry
+  local found_primary=0
+
+  if [[ ! -d "$GADGET_ROOT/configs" ]] || [[ -L "$GADGET_ROOT/configs" ]]; then
+    echo "USB gadget configurations directory is unavailable or unsafe" >&2
+    return 1
+  fi
+  # Configfs may add regular attributes across kernel versions. They cannot
+  # expose functions, so tolerate them. Every real child directory is a USB
+  # configuration and every symlink is unexpected here; only c.1 is allowed.
+  for entry in "$GADGET_ROOT/configs"/* "$GADGET_ROOT/configs"/.[!.]* "$GADGET_ROOT/configs"/..?*; do
+    [[ -e "$entry" ]] || [[ -L "$entry" ]] || continue
+    if [[ -L "$entry" ]]; then
+      echo "refusing USB gadget with a linked configuration entry" >&2
+      return 1
+    elif [[ -d "$entry" ]]; then
+      if [[ "$entry" != "$CONFIG_ROOT" ]]; then
+        echo "refusing USB gadget with more than configuration c.1" >&2
+        return 1
+      fi
+      found_primary=1
+    elif [[ ! -f "$entry" ]]; then
+      echo "refusing USB gadget with an unsafe configuration entry" >&2
+      return 1
+    fi
+  done
+  if ((!found_primary)); then
+    echo "USB gadget configuration c.1 is unavailable" >&2
+    return 1
+  fi
+}
+
+validate_single_mass_storage_lun() {
+  local entry
+  local found_lun_zero=0
+  local mass_storage_root="$FUNCTION_ROOT/mass_storage.0"
+
+  if [[ ! -d "$mass_storage_root" ]] || [[ -L "$mass_storage_root" ]]; then
+    echo "USB mass-storage function is unavailable or unsafe" >&2
+    return 1
+  fi
+  # In this kernel every configfs child directory of a mass-storage function
+  # is a dynamically created LUN (the group parser accepts NAME.NUMBER, not
+  # only lun.NUMBER). Regular attributes such as stall and optional
+  # num_buffers are harmless and must remain compatible across kernel builds.
+  for entry in "$mass_storage_root"/* "$mass_storage_root"/.[!.]* "$mass_storage_root"/..?*; do
+    [[ -e "$entry" ]] || [[ -L "$entry" ]] || continue
+    if [[ -L "$entry" ]]; then
+      echo "refusing USB mass storage with a linked function entry" >&2
+      return 1
+    elif [[ -d "$entry" ]]; then
+      if [[ "$entry" != "$mass_storage_root/lun.0" ]]; then
+        echo "refusing USB mass storage with more than LUN 0" >&2
+        return 1
+      fi
+      found_lun_zero=1
+    elif [[ ! -f "$entry" ]]; then
+      echo "refusing USB mass storage with an unsafe function entry" >&2
+      return 1
+    fi
+  done
+  if ((!found_lun_zero)); then
+    echo "USB mass-storage LUN 0 is unavailable" >&2
+    return 1
+  fi
+}
+
+validate_no_unowned_config_links() {
+  local entry
+  for entry in "$CONFIG_ROOT"/* "$CONFIG_ROOT"/.[!.]* "$CONFIG_ROOT"/..?*; do
+    [[ -e "$entry" ]] || [[ -L "$entry" ]] || continue
+    if [[ -L "$entry" ]]; then
+      echo "refusing to configure USB with an unowned function link" >&2
+      return 1
+    fi
+  done
+}
+
+validate_managed_storage_topology() {
+  validate_single_configuration && validate_single_mass_storage_lun
+}
+
+validate_managed_storage_personality() {
+  local adb_enabled=0
+  local configured_function
+  local expected_configuration="Storage"
+  local expected_product="$STORAGE_ONLY_PID"
+  local expected_vendor="$STORAGE_ONLY_VID"
+
+  validate_managed_storage_topology || return 1
+
+  if [[ -r "$ADB_PARAM" ]] && [[ "$(< "$ADB_PARAM")" == "1" ]]; then
+    adb_enabled=1
+    expected_configuration="NCM+ADB+Storage"
+    expected_product="0x1234"
+    expected_vendor="0x04D8"
+  elif [[ ! "$STORAGE_ONLY_VID" =~ ^0[xX][0-9a-fA-F]{4}$ ]] || \
+       [[ ! "$STORAGE_ONLY_PID" =~ ^0[xX][0-9a-fA-F]{4}$ ]] || \
+       [[ "$STORAGE_ONLY_VID" =~ ^0[xX]04[dD]8$ && "$STORAGE_ONLY_PID" =~ ^0[xX]1234$ ]]; then
+    echo "ADB-off storage requires a distinct owner-approved USB VID/PID" >&2
+    return 1
+  fi
+
+  # Re-enumeration is deliberately narrower than configuration: it may only
+  # bounce a complete personality whose sole storage backing is the manager's
+  # generated image. It never repairs links, descriptors, or LUN policy and
+  # therefore cannot raw-bind a partially configured gadget.
+  if [[ ! -r "$GADGET_ROOT/idVendor" ]] || ! usb_id_is "$(< "$GADGET_ROOT/idVendor")" "$expected_vendor" || \
+     [[ ! -r "$GADGET_ROOT/idProduct" ]] || ! usb_id_is "$(< "$GADGET_ROOT/idProduct")" "$expected_product" || \
+     [[ ! -r "$CONFIG_ROOT/strings/0x409/configuration" ]] || \
+     [[ "$(< "$CONFIG_ROOT/strings/0x409/configuration")" != "$expected_configuration" ]]; then
+    echo "refusing to re-enumerate an unexpected USB personality" >&2
+    return 1
+  fi
+  if [[ ! -r "$FUNCTION_ROOT/mass_storage.0/lun.0/file" ]] || \
+     [[ ! -r "$FUNCTION_ROOT/mass_storage.0/lun.0/ro" ]] || \
+     [[ ! -r "$FUNCTION_ROOT/mass_storage.0/lun.0/removable" ]] || \
+     [[ ! -r "$FUNCTION_ROOT/mass_storage.0/stall" ]] || \
+     [[ "$(< "$FUNCTION_ROOT/mass_storage.0/lun.0/file")" != "$MANAGED_BACKING_FILE" ]] || \
+     [[ "$(< "$FUNCTION_ROOT/mass_storage.0/lun.0/ro")" != "1" ]] || \
+     [[ "$(< "$FUNCTION_ROOT/mass_storage.0/lun.0/removable")" != "1" ]] || \
+     [[ "$(< "$FUNCTION_ROOT/mass_storage.0/stall")" != "1" ]] || \
+     ! function_link_is_exact mass_storage.0; then
+    echo "refusing to re-enumerate an unsafe or unmanaged USB storage LUN" >&2
+    return 1
+  fi
+
+  if ((adb_enabled)); then
+    if ! function_link_is_exact ncm.0 || ! function_link_is_exact ffs.adb; then
+      echo "refusing to re-enumerate a partial ADB USB personality" >&2
+      return 1
+    fi
+  elif [[ -L "$CONFIG_ROOT/ncm.0" ]] || [[ -L "$CONFIG_ROOT/ffs.adb" ]]; then
+    echo "refusing to re-enumerate unexpected debug USB functions" >&2
+    return 1
+  fi
+
+  # Reject every unrecognized function, including functions another process
+  # may have added. Descriptor directories are not symbolic links.
+  for configured_function in "$CONFIG_ROOT"/*; do
+    [[ -L "$configured_function" ]] || continue
+    case "${configured_function##*/}" in
+      mass_storage.0) ;;
+      ncm.0|ffs.adb)
+        if ((!adb_enabled)); then
+          echo "refusing to re-enumerate unexpected debug USB functions" >&2
+          return 1
+        fi
+        ;;
+      *)
+        echo "refusing to re-enumerate an unexpected USB function" >&2
+        return 1
+        ;;
+    esac
+  done
+}
+
+reenumerate_managed_storage() {
+  local current_udc=""
+
+  if [[ -r "$GADGET_ROOT/UDC" ]]; then
+    current_udc="$(< "$GADGET_ROOT/UDC")"
+  fi
+  if [[ "$current_udc" != "$UDC_NAME" ]] || ! validate_managed_storage_personality; then
+    unbind_gadget
+    echo "USB storage re-enumeration validation failed; leaving gadget unbound" >&2
+    return 1
+  fi
+
+  # Keep descriptors, function links, and the populated read-only LUN intact.
+  # A full one-second disconnect makes hosts that stop polling an initially
+  # empty removable LUN discover the newly inserted medium on the next bind.
+  # From this point, every failure stays unbound.
+  unbind_gadget
+  "$SLEEP_BIN" 1
+  if ! validate_managed_storage_personality; then
+    unbind_gadget
+    echo "USB storage changed during re-enumeration; leaving gadget unbound" >&2
+    return 1
+  fi
+  current_udc="$(< "$GADGET_ROOT/UDC")"
+  if [[ -n "$current_udc" ]]; then
+    unbind_gadget
+    echo "USB gadget rebound unexpectedly during storage re-enumeration" >&2
+    return 1
+  fi
+  bind_gadget
+}
+
 finalize_storage_stop() {
   local lun_root="$FUNCTION_ROOT/mass_storage.0/lun.0"
   local backing_file=""
@@ -288,6 +494,14 @@ configure_gadget() {
   # instead of mixing the old functions with a new VID/PID personality.
   RESTORE_BINDING=0
 
+  # Never bind stale dynamic LUNs, alternate configurations, or unowned
+  # function links. They may reference private or writable media. Preserve all
+  # foreign state for diagnosis, but keep the UDC unbound and our links absent.
+  if ! validate_managed_storage_topology || ! validate_no_unowned_config_links; then
+    echo "refusing unsafe pre-existing USB gadget topology" >&2
+    return 1
+  fi
+
   write_attr "$vendor_id" "$GADGET_ROOT/idVendor"
   write_attr "$product_id" "$GADGET_ROOT/idProduct"
   write_attr "$(read_serial)" "$GADGET_ROOT/strings/0x409/serialnumber"
@@ -386,6 +600,9 @@ case "${1:-}" in
   ensure-requested-personality)
     ensure_requested_personality
     ;;
+  reenumerate-managed-storage)
+    reenumerate_managed_storage
+    ;;
   finalize-storage-stop)
     finalize_storage_stop
     ;;
@@ -393,7 +610,7 @@ case "${1:-}" in
     prepare_storage_start
     ;;
   *)
-    echo "usage: $0 {configure <0|1>|bind|unbind|ensure-requested-personality|finalize-storage-stop|prepare-storage-start}" >&2
+    echo "usage: $0 {configure <0|1>|bind|unbind|ensure-requested-personality|reenumerate-managed-storage|finalize-storage-stop|prepare-storage-start}" >&2
     exit 2
     ;;
 esac

--- a/userspace/root/usr/comma/usb_gadget.sh
+++ b/userspace/root/usr/comma/usb_gadget.sh
@@ -383,6 +383,9 @@ case "${1:-}" in
   unbind)
     unbind_gadget
     ;;
+  ensure-requested-personality)
+    ensure_requested_personality
+    ;;
   finalize-storage-stop)
     finalize_storage_stop
     ;;
@@ -390,7 +393,7 @@ case "${1:-}" in
     prepare_storage_start
     ;;
   *)
-    echo "usage: $0 {configure <0|1>|bind|unbind|finalize-storage-stop|prepare-storage-start}" >&2
+    echo "usage: $0 {configure <0|1>|bind|unbind|ensure-requested-personality|finalize-storage-stop|prepare-storage-start}" >&2
     exit 2
     ;;
 esac

--- a/userspace/root/usr/comma/usb_storage.py
+++ b/userspace/root/usr/comma/usb_storage.py
@@ -46,7 +46,7 @@ MIN_FREE_PERCENT = 10.0
 LOG_ID_V2_PATTERN = r"[a-f0-9]{8}--[a-z0-9]{10}"
 TIMESTAMP_PATTERN = r"[0-9]{4}-[0-9]{2}-[0-9]{2}--[0-9]{2}-[0-9]{2}-[0-9]{2}"
 SEGMENT_NAME_RE = re.compile(
-  rf"^(?:{LOG_ID_V2_PATTERN}|[a-f0-9]{{16}}[|_](?:{TIMESTAMP_PATTERN}|{LOG_ID_V2_PATTERN}))--[0-9]+$",
+  rf"^(?:{LOG_ID_V2_PATTERN}|{TIMESTAMP_PATTERN}|[a-f0-9]{{16}}[|_](?:{TIMESTAMP_PATTERN}|{LOG_ID_V2_PATTERN}))--[0-9]+$",
 )
 WINDOWS_FORBIDDEN_CHARS = frozenset('<>:"/\\|?*')
 WINDOWS_RESERVED_BASENAMES = frozenset({"CON", "PRN", "AUX", "NUL"} | {f"COM{number}" for number in range(1, 10)} | {f"LPT{number}" for number in range(1, 10)})
@@ -131,12 +131,18 @@ def _validate_portable_name(name: str) -> None:
     raise UnsafeTreeError(f"filename uses a reserved DOS basename: {name!r}")
 
 
+def _portable_name_key(name: str) -> str:
+  """Return a conservative key for names that collide on FAT/Windows."""
+  _validate_portable_name(name)
+  return unicodedata.normalize("NFC", name).casefold()
+
+
 def _portable_segment_name(name: str) -> str:
   # Legacy route identifiers use '|' between dongle ID and timestamp.  The
   # openpilot route parser also accepts '_' there, and unlike '|', '_' is valid
   # on Windows.  Current counter/random route identifiers pass through intact.
   portable_name = name.replace("|", "_")
-  _validate_portable_name(portable_name)
+  _portable_name_key(portable_name)
   return portable_name
 
 
@@ -383,10 +389,6 @@ def _entry_record(path: Path, relative_path: Path) -> EntryRecord:
     raise UnsafeTreeError(f"contains non-regular entry: {relative_path}")
   if path.name.endswith(".lock"):
     raise UnsafeTreeError(f"contains active lock: {relative_path}")
-  # nbdkit 1.36's floppy plugin assigns zero-length files a free first cluster,
-  # producing a FAT chain that macOS fsck and other strict readers reject.
-  if stat.S_ISREG(mode) and metadata.st_size == 0:
-    raise UnsafeTreeError(f"contains empty file unsupported by nbdkit floppy: {relative_path}")
   if stat.S_ISREG(mode) and metadata.st_size >= MAX_FAT_FILE_SIZE:
     raise UnsafeTreeError(f"contains file too large for FAT32: {relative_path}")
   return EntryRecord(
@@ -425,6 +427,8 @@ def _scan_tree(root: Path) -> tuple[EntryRecord, ...]:
     except OSError as exc:
       raise UnsafeTreeError(f"cannot scan {relative_directory or Path('.')}: {exc}") from exc
 
+    portable_names: dict[str, str] = {}
+    children: list[tuple[Path, EntryRecord]] = []
     for entry in entries:
       relative_path = relative_directory / entry.name
       path = directory / entry.name
@@ -432,9 +436,26 @@ def _scan_tree(root: Path) -> tuple[EntryRecord, ...]:
         record = _entry_record(path, relative_path)
       except OSError as exc:
         raise UnsafeTreeError(f"cannot inspect {relative_path}: {exc}") from exc
+      if not record.is_directory and record.size == 0:
+        # nbdkit 1.36's floppy plugin gives empty files a free first cluster,
+        # producing an invalid FAT chain. There is no payload to recover, so
+        # omit only the empty artifact and retain useful siblings.
+        LOG.warning("omitting empty file unsupported by nbdkit floppy: %s", relative_path)
+        continue
+      key = _portable_name_key(entry.name)
+      if key in portable_names:
+        location = relative_directory or Path(".")
+        raise UnsafeTreeError(
+          f"contains FAT/Windows-colliding names in {location}: "
+          f"{portable_names[key]!r} and {entry.name!r}",
+        )
+      portable_names[key] = entry.name
+      children.append((path, record))
+
+    for path, record in children:
       records.append(record)
       if record.is_directory:
-        scan(path, relative_path)
+        scan(path, record.relative_path)
 
   scan(root, Path())
   return tuple(records)
@@ -628,7 +649,7 @@ class SnapshotBuilder:
         except UnsafeTreeError as exc:
           excluded.append((source_segment.name, str(exc)))
           continue
-        collision_key = unicodedata.normalize("NFC", destination_name).casefold()
+        collision_key = _portable_name_key(destination_name)
         candidates.setdefault(collision_key, []).append((destination_name, source_segment))
 
       for mapped_segments in candidates.values():
@@ -643,6 +664,8 @@ class SnapshotBuilder:
         try:
           root_before = source_segment.lstat()
           first_manifest = _scan_tree(source_segment)
+          if not any(not record.is_directory for record in first_manifest):
+            raise UnsafeTreeError("contains no exportable non-empty files")
           newest_mtime_ns = max((root_before.st_mtime_ns, *(record.mtime_ns for record in first_manifest)))
           if self.wall_clock_ns() - newest_mtime_ns < self.stability_age_ns:
             raise UnsafeTreeError("segment tree is too recent to be stable")

--- a/userspace/root/usr/comma/usb_storage.py
+++ b/userspace/root/usr/comma/usb_storage.py
@@ -177,8 +177,12 @@ def _snapshot_fat_data_size(root: Path) -> int:
       child_metadata = child.lstat()
       if not stat.S_ISREG(child_metadata.st_mode) or stat.S_ISLNK(child_metadata.st_mode):
         raise StorageError(f"snapshot contains unsafe file: {child}")
-      if child_metadata.st_size:
-        total += _round_up(child_metadata.st_size, FAT_CLUSTER_SIZE)
+      if child_metadata.st_size == 0:
+        # Recheck at the last prelaunch scan: a hard-linked source inode can be
+        # truncated after snapshot construction, and nbdkit 1.36 would then
+        # emit an invalid free first cluster for it.
+        raise StorageError(f"snapshot contains an empty file unsupported by nbdkit floppy: {child}")
+      total += _round_up(child_metadata.st_size, FAT_CLUSTER_SIZE)
   return total
 
 

--- a/userspace/root/usr/comma/usb_storage.py
+++ b/userspace/root/usr/comma/usb_storage.py
@@ -42,11 +42,16 @@ DEFAULT_STABILITY_AGE_NS = 2_000_000_000
 # cable never moved. Require a stable disconnect before starting a new session
 # so a persistent exporter failure cannot flap the composite USB device.
 PHYSICAL_DETACH_DEBOUNCE_SECONDS = 2.0
-# Match loggerd's current deleter safety floor. A connected hard-link snapshot
-# can pin otherwise deleted footage, so release it as soon as either limit is
-# reached rather than letting logging exhaust userdata.
-MIN_FREE_BYTES = 5 * 1024**3
-MIN_FREE_PERCENT = 10.0
+# loggerd starts deleting at 5 GiB or 10%. Hard-link snapshots prevent those
+# deletions from reclaiming blocks until teardown, so the exporter must stop
+# *before* loggerd reaches its floor. The extra 1 GiB/1% covers the bounded USB
+# detach path and normal logger write load while snapshot/export setup finishes.
+LOGGERD_MIN_FREE_BYTES = 5 * 1024**3
+LOGGERD_MIN_FREE_PERCENT = 10.0
+EXPORT_FREE_GUARD_BYTES = 1 * 1024**3
+EXPORT_FREE_GUARD_PERCENT = 1.0
+MIN_FREE_BYTES = LOGGERD_MIN_FREE_BYTES + EXPORT_FREE_GUARD_BYTES
+MIN_FREE_PERCENT = LOGGERD_MIN_FREE_PERCENT + EXPORT_FREE_GUARD_PERCENT
 LOG_ID_V2_PATTERN = r"[a-f0-9]{8}--[a-z0-9]{10}"
 TIMESTAMP_PATTERN = r"[0-9]{4}-[0-9]{2}-[0-9]{2}--[0-9]{2}-[0-9]{2}-[0-9]{2}"
 SEGMENT_NAME_RE = re.compile(
@@ -101,6 +106,33 @@ class SessionEnd(enum.StrEnum):
   DETACHED = "detached"
   LOW_SPACE = "low-space"
   STOPPED = "stopped"
+
+
+def _decode_mountinfo_field(value: str) -> str:
+  for encoded, decoded in ((r"\040", " "), (r"\011", "\t"), (r"\012", "\n"), (r"\134", "\\")):
+    value = value.replace(encoded, decoded)
+  return value
+
+
+def _mountpoint_is_listed(
+  mountpoint: Path,
+  *,
+  mountinfo: Path = Path("/proc/self/mountinfo"),
+) -> bool:
+  """Inspect the kernel mount table without touching a possibly dead FUSE path."""
+  try:
+    lines = mountinfo.read_text().splitlines()
+  except OSError as exc:
+    raise StorageError(f"cannot inspect kernel mount table: {exc}") from exc
+
+  for line in lines:
+    left, separator, right = line.partition(" - ")
+    left_fields = left.split()
+    if not separator or len(left_fields) < 6 or len(right.split()) < 2:
+      raise StorageError("kernel mount table contains a malformed entry")
+    if _decode_mountinfo_field(left_fields[4]) == str(mountpoint):
+      return True
+  return False
 
 
 @dataclasses.dataclass(frozen=True)
@@ -597,6 +629,10 @@ class SnapshotBuilder:
   def cleanup(self) -> None:
     self._remove_snapshot_tree()
 
+  def validate_cleanup_target(self) -> None:
+    """Validate the managed snapshot tree without removing any entries."""
+    self._validate_existing_snapshot()
+
   def _candidate_segments(self) -> Iterator[Path]:
     try:
       top_entries = sorted(os.scandir(self.source), key=lambda entry: entry.name)
@@ -753,6 +789,7 @@ class StorageManager:
     image_repairer: Callable[[Path], None] = _repair_fat32_image,
     filesystem_stats: Callable[[Path], Any] = os.statvfs,
     installation_validator: Callable[[], None] = _validate_nbdkit_installation,
+    mount_checker: Callable[[Path], bool] = _mountpoint_is_listed,
   ):
     self.snapshot_builder = SnapshotBuilder(
       source,
@@ -789,12 +826,14 @@ class StorageManager:
     self.image_repairer = image_repairer
     self.filesystem_stats = filesystem_stats
     self.installation_validator = installation_validator
+    self.mount_checker = mount_checker
     self.installation_validated = False
     # Directory/filename mode mounts FUSE over mount.parent, hiding everything
     # in it. Keep readiness state next to (not inside) that mount directory.
     self.pidfile = self.mount.parent.with_suffix(".pid")
     self.process: Any | None = None
     self.export_started = False
+    self.fuse_mount_observed = False
     self.forced_unbound = False
 
   @contextmanager
@@ -917,6 +956,12 @@ class StorageManager:
     if return_code is not None:
       raise StorageError(f"nbdfuse exited unexpectedly with status {return_code}")
 
+  def _mount_is_active(self) -> bool:
+    try:
+      return self.mount_checker(self.mount.parent)
+    except OSError as exc:
+      raise StorageError(f"cannot inspect nbdfuse mount state: {exc}") from exc
+
   def _prepare_mount(self) -> None:
     if not self.mount.parent.exists():
       self.mount.parent.mkdir(parents=True, mode=0o700)
@@ -950,8 +995,14 @@ class StorageManager:
       self.installation_validated = True
     self._prepare_mount()
     disk_size, size_argument = _nbdkit_layout(self.snapshot_builder.snapshot)
+    # Give the managed FUSE mount an explicit kernel identity so forced-stop
+    # cleanup can distinguish it from every foreign filesystem fail-closed.
     command = [
       "/usr/bin/nbdfuse",
+      "-o",
+      "fsname=nbdfuse",
+      "-o",
+      "subtype=nbdfuse",
       "-P",
       str(self.pidfile),
       str(self.mount),
@@ -972,14 +1023,17 @@ class StorageManager:
     environment["TMPDIR"] = str(self.snapshot_builder.snapshot.parent)
     self.process = self.process_factory(command, close_fds=True, env=environment)
     self.export_started = True
+    self.fuse_mount_observed = False
 
     deadline = self.clock() + self.ready_timeout
     while self.clock() < deadline:
       self._ensure_child_running()
       try:
+        mounted = self._mount_is_active()
+        self.fuse_mount_observed = self.fuse_mount_observed or mounted
         pid_text = self.pidfile.read_text().strip()
         mount_metadata = self.mount.lstat()
-        ready = int(pid_text) == self.process.pid and stat.S_ISREG(mount_metadata.st_mode) and not stat.S_ISLNK(mount_metadata.st_mode)
+        ready = mounted and int(pid_text) == self.process.pid and stat.S_ISREG(mount_metadata.st_mode) and not stat.S_ISLNK(mount_metadata.st_mode)
         ready = ready and mount_metadata.st_size == disk_size
       except (FileNotFoundError, OSError, ValueError):
         ready = False
@@ -1082,13 +1136,22 @@ class StorageManager:
   def _reenumerate_media(self, stop_event: threading.Event) -> SessionEnd | None:
     if stop_event.is_set():
       return SessionEnd.STOPPED
+    if not self._has_export_capacity():
+      return SessionEnd.LOW_SPACE
 
     # Linux hosts may stop polling a removable LUN after the gadget first
     # enumerates without media. The helper performs one validated, atomic UDC
     # bounce while preserving this populated read-only managed LUN. Never use
     # the helper's raw bind action here: it cannot prove that descriptors and
     # function links form the complete requested personality.
-    self._run_gadget_helper("reenumerate-managed-storage")
+    try:
+      self._run_gadget_helper("reenumerate-managed-storage")
+    except Exception:
+      # The helper's failure contract is to leave the UDC unbound. Remember
+      # that state so teardown reconstructs the full requested personality and
+      # the retry latch waits to observe that reconstruction configure first.
+      self.forced_unbound = True
+      raise
 
     # Rebinding returns before the host necessarily reaches USB configured.
     # Bound this wait so a disconnected or non-responsive host cannot leave a
@@ -1096,6 +1159,8 @@ class StorageManager:
     deadline = self.clock() + self.ready_timeout
     while not stop_event.is_set():
       self._ensure_child_running()
+      if not self._has_export_capacity():
+        return SessionEnd.LOW_SPACE
       try:
         if self._read_lun() != str(self.mount):
           return SessionEnd.EJECTED
@@ -1128,17 +1193,23 @@ class StorageManager:
     if getattr(result, "returncode", 0) != 0:
       raise StorageError(f"gadget helper {action} failed with status {result.returncode}")
 
-  def _release_lun_with_fallback(self) -> None:
+  def _release_lun_with_fallback(self, *, force_unbind: bool = False) -> None:
+    if force_unbind:
+      # Low space is more urgent than a polite SCSI eject: while this snapshot
+      # pins blocks, loggerd's deleter cannot reclaim them. Disconnect first so
+      # PREVENT MEDIUM REMOVAL cannot consume the guard margin.
+      self.forced_unbound = True
+      self._run_gadget_helper("unbind")
     try:
       self._clear_lun()
     except LunBusyError:
       LOG.warning("host prevented media removal; forcing a bounded UDC unbind")
-      self._run_gadget_helper("unbind")
       self.forced_unbound = True
+      self._run_gadget_helper("unbind")
       self._clear_lun()
 
   def _unmount(self) -> None:
-    if not self.export_started:
+    if not self.fuse_mount_observed and not self._mount_is_active():
       return
     deadline = self.clock() + self.stop_timeout
     last_status = 1
@@ -1156,6 +1227,7 @@ class StorageManager:
         raise StorageError("fusermount3 timed out") from exc
       last_status = getattr(result, "returncode", 0)
       if last_status == 0:
+        self.fuse_mount_observed = False
         return
       # Releasing a configfs LUN closes its backing file asynchronously on
       # the device's 4.9 kernel.  A normal eject can therefore leave a short
@@ -1191,21 +1263,30 @@ class StorageManager:
     except FileNotFoundError:
       pass
 
-  def teardown(self, *, rebind: bool = True) -> bool:
+  def teardown(self, *, rebind: bool = True, force_unbind: bool = False) -> bool:
     """Release session state and report whether the gadget was self-rebound."""
     # This order is a safety invariant: configfs must release the backing file
     # before FUSE disappears, and the hard-link namespace must outlive nbdkit.
     try:
-      self._release_lun_with_fallback()
+      self._release_lun_with_fallback(force_unbind=force_unbind)
     except BaseException as exc:
       # If configfs still owns our path, tearing down FUSE would leave the USB
       # function backed by a disappearing file. Keep the read-only export and
       # snapshot alive; UDC orchestration can unbind and retry this service.
       raise StorageError("refusing to tear down an attached LUN") from exc
-    # Each operation is intentionally gated on the previous one succeeding.
-    # A failed unmount or child stop leaves all later backing state intact.
-    self._unmount()
-    self._stop_child()
+    # Each operation is intentionally gated on the previous one succeeding. If
+    # readiness observed a FUSE mount, unmount before stopping its daemon. If no
+    # mount ever appeared, stop the child first, then recheck: this closes the
+    # race where nbdfuse mounts between the readiness timeout and teardown.
+    if self.fuse_mount_observed or self._mount_is_active():
+      self.fuse_mount_observed = True
+      self._unmount()
+      self._stop_child()
+    else:
+      self._stop_child()
+      if self._mount_is_active():
+        self.fuse_mount_observed = True
+        self._unmount()
     self.snapshot_builder.cleanup()
 
     if self.forced_unbound and rebind:
@@ -1245,6 +1326,11 @@ class StorageManager:
         snapshot = self.snapshot_builder.build()
         if stop_event.is_set():
           end = SessionEnd.STOPPED
+        elif not self._has_export_capacity():
+          # Building the hard-link snapshot can immediately push available
+          # space below our guarded floor. Do not start or attach an exporter
+          # until capacity has been checked against the pinned namespace.
+          end = SessionEnd.LOW_SPACE
         elif self._read_udc_state() not in self.CONFIGURED_UDC_STATES:
           end = SessionEnd.DETACHED
         else:
@@ -1258,7 +1344,10 @@ class StorageManager:
         LOG.exception("USB storage session failed safely; waiting for physical detach before retry")
       finally:
         try:
-          self_rebound = self.teardown(rebind=not stop_event.is_set())
+          self_rebound = self.teardown(
+            rebind=not stop_event.is_set(),
+            force_unbind=media_attached and end == SessionEnd.LOW_SPACE,
+          )
         except BaseException as teardown_failure:
           if failure is None:
             raise
@@ -1286,7 +1375,10 @@ class StorageManager:
 
       if stop_event.is_set() or end == SessionEnd.STOPPED:
         break
-      if end in (SessionEnd.EJECTED, SessionEnd.LOW_SPACE) and not self._wait_for_physical_detach(stop_event):
+      if end in (SessionEnd.EJECTED, SessionEnd.LOW_SPACE) and not self._wait_for_physical_detach(
+        stop_event,
+        require_reconfigured=self_rebound,
+      ):
         break
 
     return completed_sessions

--- a/userspace/root/usr/comma/usb_storage.py
+++ b/userspace/root/usr/comma/usb_storage.py
@@ -1079,16 +1079,52 @@ class StorageManager:
       self.sleep(self.poll_interval)
     return SessionEnd.STOPPED
 
+  def _reenumerate_media(self, stop_event: threading.Event) -> SessionEnd | None:
+    if stop_event.is_set():
+      return SessionEnd.STOPPED
+
+    # Linux hosts may stop polling a removable LUN after the gadget first
+    # enumerates without media. The helper performs one validated, atomic UDC
+    # bounce while preserving this populated read-only managed LUN. Never use
+    # the helper's raw bind action here: it cannot prove that descriptors and
+    # function links form the complete requested personality.
+    self._run_gadget_helper("reenumerate-managed-storage")
+
+    # Rebinding returns before the host necessarily reaches USB configured.
+    # Bound this wait so a disconnected or non-responsive host cannot leave a
+    # hard-link snapshot pinned indefinitely.
+    deadline = self.clock() + self.ready_timeout
+    while not stop_event.is_set():
+      self._ensure_child_running()
+      try:
+        if self._read_lun() != str(self.mount):
+          return SessionEnd.EJECTED
+      except LunUnavailableError:
+        return SessionEnd.DETACHED
+      try:
+        if self._read_udc_state() in self.CONFIGURED_UDC_STATES:
+          return None
+      except UdcUnavailableError:
+        pass
+      remaining = deadline - self.clock()
+      if remaining <= 0:
+        raise StorageError("timed out waiting for USB storage re-enumeration")
+      self.sleep(min(self.poll_interval, remaining))
+    return SessionEnd.STOPPED
+
   def _run_gadget_helper(self, action: str) -> None:
-    if action not in ("unbind", "ensure-requested-personality"):
+    if action not in ("unbind", "ensure-requested-personality", "reenumerate-managed-storage"):
       raise StorageError(f"invalid gadget helper action: {action}")
     # usb_gadget.sh takes the shared flock itself. Never invoke it from within
     # _gadget_locked(), or both processes would deadlock.
-    result = self.command_runner(
-      [str(self.gadget_helper), action],
-      check=False,
-      timeout=self.stop_timeout,
-    )
+    try:
+      result = self.command_runner(
+        [str(self.gadget_helper), action],
+        check=False,
+        timeout=self.stop_timeout,
+      )
+    except subprocess.TimeoutExpired as exc:
+      raise StorageError(f"gadget helper {action} timed out") from exc
     if getattr(result, "returncode", 0) != 0:
       raise StorageError(f"gadget helper {action} failed with status {result.returncode}")
 
@@ -1104,13 +1140,33 @@ class StorageManager:
   def _unmount(self) -> None:
     if not self.export_started:
       return
-    result = self.command_runner(
-      ["/usr/bin/fusermount3", "-u", str(self.mount.parent)],
-      check=False,
-      timeout=self.stop_timeout,
-    )
-    if getattr(result, "returncode", 0) != 0:
-      raise StorageError(f"fusermount3 failed with status {result.returncode}")
+    deadline = self.clock() + self.stop_timeout
+    last_status = 1
+    while True:
+      remaining = deadline - self.clock()
+      if remaining <= 0:
+        raise StorageError(f"fusermount3 failed with status {last_status}")
+      try:
+        result = self.command_runner(
+          ["/usr/bin/fusermount3", "-u", str(self.mount.parent)],
+          check=False,
+          timeout=remaining,
+        )
+      except subprocess.TimeoutExpired as exc:
+        raise StorageError("fusermount3 timed out") from exc
+      last_status = getattr(result, "returncode", 0)
+      if last_status == 0:
+        return
+      # Releasing a configfs LUN closes its backing file asynchronously on
+      # the device's 4.9 kernel.  A normal eject can therefore leave a short
+      # window where a non-lazy FUSE unmount reports EBUSY even though the LUN
+      # has already read back empty. Retry only within the existing bounded
+      # stop budget; exhaustion still fails closed before stopping nbdkit or
+      # removing its snapshot.
+      remaining = deadline - self.clock()
+      if remaining <= 0:
+        raise StorageError(f"fusermount3 failed with status {last_status}")
+      self.sleep(min(self.poll_interval, remaining))
 
   def _stop_child(self) -> None:
     if self.process is None:
@@ -1195,7 +1251,8 @@ class StorageManager:
           self._start_export()
           self._set_lun()
           media_attached = True
-          end = self.monitor(stop_event)
+          reenumeration_end = self._reenumerate_media(stop_event)
+          end = reenumeration_end if reenumeration_end is not None else self.monitor(stop_event)
       except Exception as exc:
         failure = exc
         LOG.exception("USB storage session failed safely; waiting for physical detach before retry")

--- a/userspace/root/usr/comma/usb_storage.py
+++ b/userspace/root/usr/comma/usb_storage.py
@@ -63,6 +63,7 @@ FAT32_COMPATIBLE_DATA_CLUSTERS = FAT32_MIN_DATA_CLUSTERS + 16
 # inversion and yields 65,541 data clusters; arbitrary sizes can trip an
 # internal equality assertion in that plugin version.
 MIN_COMPATIBLE_DISK_SIZE = 1_075_445_760
+SUPPORTED_NBDKIT_FLOPPY_VERSION = "1.36.3"
 FAT32_END_OF_CHAIN = 0x0FFFFFF8
 FAT32_BAD_CLUSTER = 0x0FFFFFF7
 
@@ -112,6 +113,30 @@ class EntryRecord:
 class SnapshotResult:
   included: tuple[str, ...]
   excluded: tuple[tuple[str, str], ...]
+
+
+def _validate_nbdkit_installation(
+  runner: Callable[..., Any] = subprocess.run,
+) -> None:
+  command = ["/usr/bin/nbdkit", "--filter=cow", "floppy", "--dump-plugin"]
+  try:
+    result = runner(command, check=False, capture_output=True, text=True, timeout=5.0)
+  except (OSError, subprocess.SubprocessError) as exc:
+    raise StorageError(f"cannot inspect the installed nbdkit floppy exporter: {exc}") from exc
+  if result.returncode != 0:
+    raise StorageError(f"nbdkit floppy/COW probe failed with status {result.returncode}")
+
+  fields: dict[str, str] = {}
+  for line in result.stdout.splitlines():
+    key, separator, value = line.partition("=")
+    if separator:
+      fields[key] = value
+  if fields.get("name") != "floppy" or fields.get("cow_name") != "cow":
+    raise StorageError("installed nbdkit is missing the expected floppy plugin or COW filter")
+  if fields.get("version") != SUPPORTED_NBDKIT_FLOPPY_VERSION:
+    raise StorageError(
+      f"unsupported nbdkit floppy version {fields.get('version', 'unknown')!r}; expected {SUPPORTED_NBDKIT_FLOPPY_VERSION}",
+    )
 
 
 def _validate_portable_name(name: str) -> None:
@@ -444,10 +469,9 @@ def _scan_tree(root: Path) -> tuple[EntryRecord, ...]:
         continue
       key = _portable_name_key(entry.name)
       if key in portable_names:
-        location = relative_directory or Path(".")
-        raise UnsafeTreeError(
-          f"contains FAT/Windows-colliding names in {location}: "
-          f"{portable_names[key]!r} and {entry.name!r}",
+          location = relative_directory or Path(".")
+          raise UnsafeTreeError(
+            f"contains FAT/Windows-colliding names in {location}: {portable_names[key]!r} and {entry.name!r}",
         )
       portable_names[key] = entry.name
       children.append((path, record))
@@ -715,6 +739,7 @@ class StorageManager:
     ready_timeout: float = 20.0,
     stop_timeout: float = 5.0,
     poll_interval: float = 0.1,
+    idle_poll_interval: float = 1.0,
     process_factory: Callable[..., Any] = subprocess.Popen,
     command_runner: Callable[..., Any] = subprocess.run,
     clock: Callable[[], float] = time.monotonic,
@@ -723,6 +748,7 @@ class StorageManager:
     stability_age_ns: int = DEFAULT_STABILITY_AGE_NS,
     image_repairer: Callable[[Path], None] = _repair_fat32_image,
     filesystem_stats: Callable[[Path], Any] = os.statvfs,
+    installation_validator: Callable[[], None] = _validate_nbdkit_installation,
   ):
     self.snapshot_builder = SnapshotBuilder(
       source,
@@ -745,18 +771,21 @@ class StorageManager:
       raise StorageError("gadget lock path must be absolute")
     if not self.gadget_helper.is_absolute():
       raise StorageError("gadget helper path must be absolute")
-    if min(ready_timeout, stop_timeout, poll_interval) <= 0:
+    if min(ready_timeout, stop_timeout, poll_interval, idle_poll_interval) <= 0:
       raise StorageError("timeouts and poll interval must be positive")
 
     self.ready_timeout = ready_timeout
     self.stop_timeout = stop_timeout
     self.poll_interval = poll_interval
+    self.idle_poll_interval = idle_poll_interval
     self.process_factory = process_factory
     self.command_runner = command_runner
     self.clock = clock
     self.sleep = sleep
     self.image_repairer = image_repairer
     self.filesystem_stats = filesystem_stats
+    self.installation_validator = installation_validator
+    self.installation_validated = False
     # Directory/filename mode mounts FUSE over mount.parent, hiding everything
     # in it. Keep readiness state next to (not inside) that mount directory.
     self.pidfile = self.mount.parent.with_suffix(".pid")
@@ -912,6 +941,9 @@ class StorageManager:
       self.pidfile.unlink()
 
   def _start_export(self) -> None:
+    if not self.installation_validated:
+      self.installation_validator()
+      self.installation_validated = True
     self._prepare_mount()
     disk_size, size_argument = _nbdkit_layout(self.snapshot_builder.snapshot)
     command = [
@@ -961,7 +993,7 @@ class StorageManager:
       except UdcUnavailableError:
         # The UDC may appear after this boot service starts.
         pass
-      self.sleep(self.poll_interval)
+      self.sleep(self.idle_poll_interval)
     return False
 
   def _wait_for_source_while_attached(self, stop_event: threading.Event) -> bool:
@@ -974,7 +1006,7 @@ class StorageManager:
         return False
       if state in self.CONFIGURED_UDC_STATES and self.snapshot_builder.source_is_ready() and self._has_export_capacity():
         return True
-      self.sleep(self.poll_interval)
+      self.sleep(self.idle_poll_interval)
     return False
 
   def _has_export_capacity(self) -> bool:
@@ -996,7 +1028,7 @@ class StorageManager:
       except UdcUnavailableError:
         # A disappearing UDC is also a physical/configfs detachment.
         return True
-      self.sleep(self.poll_interval)
+      self.sleep(self.idle_poll_interval)
     return False
 
   def monitor(self, stop_event: threading.Event) -> SessionEnd:
@@ -1172,6 +1204,7 @@ def _build_parser() -> argparse.ArgumentParser:
   parser.add_argument("--gadget-helper", default="/usr/comma/usb_gadget.sh")
   parser.add_argument("--ready-timeout", type=float, default=20.0)
   parser.add_argument("--stop-timeout", type=float, default=5.0)
+  parser.add_argument("--idle-poll-interval", type=float, default=1.0)
   return parser
 
 
@@ -1195,6 +1228,7 @@ def main(argv: Sequence[str] | None = None) -> int:
       gadget_helper=arguments.gadget_helper,
       ready_timeout=arguments.ready_timeout,
       stop_timeout=arguments.stop_timeout,
+      idle_poll_interval=arguments.idle_poll_interval,
     )
     completed_sessions = manager.run(stop_event)
     LOG.info("stopped after %d completed storage sessions", completed_sessions)

--- a/userspace/root/usr/comma/usb_storage.py
+++ b/userspace/root/usr/comma/usb_storage.py
@@ -1,0 +1,1184 @@
+#!/usr/bin/env python3
+"""Expose completed openpilot route segments as a read-only USB disk.
+
+The FAT image is synthesized by nbdkit from a hard-link snapshot.  Keeping a
+separate directory namespace is important: loggerd's deleter may unlink the
+original route while a host is still copying it, but the snapshot link remains
+valid until the USB session ends.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import enum
+import errno
+import fcntl
+import logging
+import os
+from pathlib import Path
+import re
+import signal
+import stat
+import struct
+import subprocess
+import threading
+import time
+import unicodedata
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
+from typing import Any
+
+
+LOG = logging.getLogger("usb-storage")
+
+MANAGED_SNAPSHOT_NAME = "usb-storage-snapshot"
+MANAGED_MOUNT_DIRECTORY = "usb-storage"
+MANAGED_MOUNT_NAME = "footage.img"
+# nbdkit-floppy rejects files whose size cannot fit in its uint32_t field.
+MAX_FAT_FILE_SIZE = (1 << 32) - 1
+DEFAULT_STABILITY_AGE_NS = 2_000_000_000
+# Match loggerd's current deleter safety floor. A connected hard-link snapshot
+# can pin otherwise deleted footage, so release it as soon as either limit is
+# reached rather than letting logging exhaust userdata.
+MIN_FREE_BYTES = 5 * 1024**3
+MIN_FREE_PERCENT = 10.0
+LOG_ID_V2_PATTERN = r"[a-f0-9]{8}--[a-z0-9]{10}"
+TIMESTAMP_PATTERN = r"[0-9]{4}-[0-9]{2}-[0-9]{2}--[0-9]{2}-[0-9]{2}-[0-9]{2}"
+SEGMENT_NAME_RE = re.compile(
+  rf"^(?:{LOG_ID_V2_PATTERN}|[a-f0-9]{{16}}[|_](?:{TIMESTAMP_PATTERN}|{LOG_ID_V2_PATTERN}))--[0-9]+$",
+)
+WINDOWS_FORBIDDEN_CHARS = frozenset('<>:"/\\|?*')
+WINDOWS_RESERVED_BASENAMES = frozenset({"CON", "PRN", "AUX", "NUL"} | {f"COM{number}" for number in range(1, 10)} | {f"LPT{number}" for number in range(1, 10)})
+SECTOR_SIZE = 512
+# nbdkit 1.36's floppy plugin fixes FAT32 clusters at 32 sectors.
+FAT_CLUSTER_SIZE = 32 * SECTOR_SIZE
+FAT32_MIN_DATA_CLUSTERS = 65_525
+# Microsoft recommends staying at least 16 clusters above the FAT16/FAT32
+# cutover because some FAT implementations classify near-boundary volumes
+# incorrectly.
+FAT32_COMPATIBLE_DATA_CLUSTERS = FAT32_MIN_DATA_CLUSTERS + 16
+# Small exports need padding or operating systems classify nbdkit's FAT32
+# volume as FAT16.  This exact size is accepted by nbdkit 1.36's size
+# inversion and yields 65,541 data clusters; arbitrary sizes can trip an
+# internal equality assertion in that plugin version.
+MIN_COMPATIBLE_DISK_SIZE = 1_075_445_760
+FAT32_END_OF_CHAIN = 0x0FFFFFF8
+FAT32_BAD_CLUSTER = 0x0FFFFFF7
+
+
+class StorageError(RuntimeError):
+  pass
+
+
+class UnsafeTreeError(StorageError):
+  pass
+
+
+class LunUnavailableError(StorageError):
+  pass
+
+
+class LunBusyError(StorageError):
+  pass
+
+
+class ForeignLunError(StorageError):
+  pass
+
+
+class UdcUnavailableError(StorageError):
+  pass
+
+
+class SessionEnd(enum.StrEnum):
+  EJECTED = "ejected"
+  DETACHED = "detached"
+  LOW_SPACE = "low-space"
+  STOPPED = "stopped"
+
+
+@dataclasses.dataclass(frozen=True)
+class EntryRecord:
+  relative_path: Path
+  is_directory: bool
+  device: int
+  inode: int
+  size: int
+  mtime_ns: int
+
+
+@dataclasses.dataclass(frozen=True)
+class SnapshotResult:
+  included: tuple[str, ...]
+  excluded: tuple[tuple[str, str], ...]
+
+
+def _validate_portable_name(name: str) -> None:
+  try:
+    name.encode("utf-8", errors="strict")
+    utf16_length = len(name.encode("utf-16-le", errors="strict")) // 2
+  except UnicodeEncodeError as exc:
+    raise UnsafeTreeError(f"filename is not valid Unicode: {name!r}") from exc
+
+  if not name or utf16_length > 255:
+    raise UnsafeTreeError(f"filename is too long for VFAT: {name!r}")
+  if name.endswith((".", " ")):
+    raise UnsafeTreeError(f"filename has a Windows-forbidden suffix: {name!r}")
+  if any(unicodedata.category(character).startswith("C") or character in WINDOWS_FORBIDDEN_CHARS for character in name):
+    raise UnsafeTreeError(f"filename contains a Windows-forbidden character: {name!r}")
+  if name.split(".", maxsplit=1)[0].upper() in WINDOWS_RESERVED_BASENAMES:
+    raise UnsafeTreeError(f"filename uses a reserved DOS basename: {name!r}")
+
+
+def _portable_segment_name(name: str) -> str:
+  # Legacy route identifiers use '|' between dongle ID and timestamp.  The
+  # openpilot route parser also accepts '_' there, and unlike '|', '_' is valid
+  # on Windows.  Current counter/random route identifiers pass through intact.
+  portable_name = name.replace("|", "_")
+  _validate_portable_name(portable_name)
+  return portable_name
+
+
+def _round_up(value: int, alignment: int) -> int:
+  return ((value + alignment - 1) // alignment) * alignment
+
+
+def _lfn_entry_count(name: str) -> int:
+  _validate_portable_name(name)
+  utf16_units = len(name.encode("utf-16-le", errors="strict")) // 2
+  # nbdkit 1.36 intentionally emits one extra zero-padded LFN slot when the
+  # length is an exact multiple of 13; mirror its loop exactly.
+  return 1 + utf16_units // 13
+
+
+def _snapshot_fat_data_size(root: Path) -> int:
+  """Mirror nbdkit-floppy's directory and file cluster accounting."""
+  metadata = root.lstat()
+  if not stat.S_ISDIR(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+    raise StorageError("snapshot root is not a real directory")
+
+  total = 0
+  for directory, directory_names, file_names in os.walk(root, topdown=True, followlinks=False):
+    directory_path = Path(directory)
+    # Root has one volume-label entry; other directories have '.' and '..'.
+    directory_entries = 1 if directory_path == root else 2
+    for name in (*directory_names, *file_names):
+      directory_entries += 1 + _lfn_entry_count(name)
+    total += _round_up(directory_entries * 32, FAT_CLUSTER_SIZE)
+
+    for directory_name in directory_names:
+      child = directory_path / directory_name
+      child_metadata = child.lstat()
+      if not stat.S_ISDIR(child_metadata.st_mode) or stat.S_ISLNK(child_metadata.st_mode):
+        raise StorageError(f"snapshot contains unsafe directory: {child}")
+    for file_name in file_names:
+      child = directory_path / file_name
+      child_metadata = child.lstat()
+      if not stat.S_ISREG(child_metadata.st_mode) or stat.S_ISLNK(child_metadata.st_mode):
+        raise StorageError(f"snapshot contains unsafe file: {child}")
+      if child_metadata.st_size:
+        total += _round_up(child_metadata.st_size, FAT_CLUSTER_SIZE)
+  return total
+
+
+def _nbdkit_layout(root: Path) -> tuple[int, int | None]:
+  """Return (expected image size, optional nbdkit size= padding)."""
+  used_clusters = _snapshot_fat_data_size(root) // FAT_CLUSTER_SIZE
+  if used_clusters < FAT32_COMPATIBLE_DATA_CLUSTERS:
+    return MIN_COMPATIBLE_DISK_SIZE, MIN_COMPATIBLE_DISK_SIZE
+
+  # Without size=, nbdkit uses exactly the allocated directory/file clusters.
+  # Omitting the option also avoids its broken size inversion for larger trees.
+  fat_clusters = (used_clusters + 2 + 4095) // 4096
+  expected_size = (65 + (2 * fat_clusters) + used_clusters) * FAT_CLUSTER_SIZE
+  return expected_size, None
+
+
+def _pread_exact(descriptor: int, length: int, offset: int) -> bytes:
+  chunks = bytearray()
+  while len(chunks) < length:
+    chunk = os.pread(descriptor, length - len(chunks), offset + len(chunks))
+    if not chunk:
+      raise StorageError("unexpected end of virtual FAT32 image")
+    chunks.extend(chunk)
+  return bytes(chunks)
+
+
+def _pwrite_exact(descriptor: int, data: bytes, offset: int) -> None:
+  written = 0
+  while written < len(data):
+    count = os.pwrite(descriptor, data[written:], offset + written)
+    if count <= 0:
+      raise StorageError("short write while repairing virtual FAT32 image")
+    written += count
+
+
+def _repair_fat32_image(path: Path) -> None:
+  """Repair nbdkit 1.36 FAT metadata that strict macOS checks reject."""
+  flags = os.O_RDWR | os.O_CLOEXEC
+  if hasattr(os, "O_NOFOLLOW"):
+    flags |= os.O_NOFOLLOW
+  descriptor = os.open(path, flags)
+  try:
+    image_metadata = os.fstat(descriptor)
+    if not stat.S_ISREG(image_metadata.st_mode) or image_metadata.st_size % SECTOR_SIZE:
+      raise StorageError("virtual FAT32 image has an invalid file type or size")
+
+    mbr = _pread_exact(descriptor, SECTOR_SIZE, 0)
+    if mbr[510:512] != b"\x55\xaa":
+      raise StorageError("virtual FAT32 image has no valid MBR signature")
+    partition = mbr[446:462]
+    if partition[4] != 0x0C or any(mbr[offset:offset + 16] != bytes(16) for offset in (462, 478, 494)):
+      raise StorageError("virtual FAT32 image has an unexpected partition table")
+    partition_lba, partition_sectors = struct.unpack_from("<II", partition, 8)
+    partition_offset = partition_lba * SECTOR_SIZE
+    partition_end = partition_offset + partition_sectors * SECTOR_SIZE
+    if partition_lba != 2048 or partition_sectors == 0 or partition_end != image_metadata.st_size:
+      raise StorageError("virtual FAT32 partition lies outside its image")
+
+    boot = bytearray(_pread_exact(descriptor, SECTOR_SIZE, partition_offset))
+    if boot[0:3] not in (bytes(3), b"\xeb\x58\x90") or boot[3:11] != b"MSWIN4.1" or boot[510:512] != b"\x55\xaa":
+      raise StorageError("virtual FAT32 boot sector is not the expected nbdkit format")
+    bytes_per_sector = struct.unpack_from("<H", boot, 11)[0]
+    sectors_per_cluster = boot[13]
+    reserved_sectors = struct.unpack_from("<H", boot, 14)[0]
+    number_of_fats = boot[16]
+    root_entries = struct.unpack_from("<H", boot, 17)[0]
+    old_total_sectors = struct.unpack_from("<H", boot, 19)[0]
+    media_descriptor = boot[21]
+    old_sectors_per_fat = struct.unpack_from("<H", boot, 22)[0]
+    sectors_per_track = struct.unpack_from("<H", boot, 24)[0]
+    number_of_heads = struct.unpack_from("<H", boot, 26)[0]
+    hidden_sectors = struct.unpack_from("<I", boot, 28)[0]
+    total_sectors = struct.unpack_from("<I", boot, 32)[0]
+    sectors_per_fat = struct.unpack_from("<I", boot, 36)[0]
+    mirroring = struct.unpack_from("<H", boot, 40)[0]
+    fat_version = struct.unpack_from("<H", boot, 42)[0]
+    root_cluster = struct.unpack_from("<I", boot, 44)[0]
+    fsinfo_sector = struct.unpack_from("<H", boot, 48)[0]
+    backup_sector = struct.unpack_from("<H", boot, 50)[0]
+    if (
+      bytes_per_sector != SECTOR_SIZE
+      or sectors_per_cluster != FAT_CLUSTER_SIZE // SECTOR_SIZE
+      or reserved_sectors != 32
+      or root_entries != 0
+      or old_total_sectors != 0
+      or media_descriptor != 0xF8
+      or old_sectors_per_fat != 0
+      or sectors_per_track not in (0, 63)
+      or number_of_heads not in (0, 255)
+      or number_of_fats != 2
+      or hidden_sectors not in (0, partition_lba)
+      or total_sectors != partition_sectors
+      or sectors_per_fat == 0
+      or mirroring != 0
+      or fat_version != 0
+      or root_cluster != 2
+      or fsinfo_sector != 1
+      or backup_sector != 6
+      or boot[64] not in (0, 0x80)
+      or boot[66] != 0x29
+      or boot[82:90] != b"FAT32   "
+    ):
+      raise StorageError("virtual FAT32 image has unexpected filesystem geometry")
+
+    fat_offset = partition_offset + reserved_sectors * SECTOR_SIZE
+    data_sector = reserved_sectors + number_of_fats * sectors_per_fat
+    if data_sector >= total_sectors:
+      raise StorageError("virtual FAT32 data region is outside the partition")
+    data_offset = partition_offset + data_sector * SECTOR_SIZE
+    data_sectors = total_sectors - data_sector
+    data_clusters = data_sectors // sectors_per_cluster
+    max_cluster = data_clusters + 1
+    fat_entry_capacity = sectors_per_fat * SECTOR_SIZE // 4
+    if (
+      data_sectors % sectors_per_cluster
+      or sectors_per_fat % sectors_per_cluster
+      or fat_entry_capacity < data_clusters + 2
+      or data_clusters < FAT32_COMPATIBLE_DATA_CLUSTERS
+      or root_cluster > max_cluster
+    ):
+      raise StorageError("virtual FAT32 image is too small or has an invalid root cluster")
+
+    expected_jump = b"\xeb\x58\x90"
+    boot[0:3] = expected_jump
+    struct.pack_into("<H", boot, 24, 63)
+    struct.pack_into("<H", boot, 26, 255)
+    struct.pack_into("<I", boot, 28, partition_lba)
+    boot[64] = 0x80
+    backup = bytearray(_pread_exact(descriptor, SECTOR_SIZE, partition_offset + backup_sector * SECTOR_SIZE))
+    if backup[3:] != bytearray(_pread_exact(descriptor, SECTOR_SIZE, partition_offset))[3:]:
+      raise StorageError("virtual FAT32 backup boot sector does not match the primary")
+    backup[:] = boot
+
+    patches: list[tuple[int, bytes]] = [
+      (partition_offset, bytes(boot)),
+      (partition_offset + backup_sector * SECTOR_SIZE, bytes(backup)),
+    ]
+    seen_root_clusters: set[int] = set()
+    seen_children: set[int] = set()
+    cluster = root_cluster
+    end_of_directory = False
+    cluster_bytes = sectors_per_cluster * SECTOR_SIZE
+    while not end_of_directory:
+      if cluster in seen_root_clusters or not (2 <= cluster <= max_cluster):
+        raise StorageError("virtual FAT32 root directory has an invalid cluster chain")
+      seen_root_clusters.add(cluster)
+      cluster_offset = data_offset + (cluster - 2) * cluster_bytes
+      directory_data = _pread_exact(descriptor, cluster_bytes, cluster_offset)
+      for entry_offset in range(0, cluster_bytes, 32):
+        entry = directory_data[entry_offset:entry_offset + 32]
+        if entry[0] == 0:
+          end_of_directory = True
+          break
+        if entry[0] == 0xE5 or entry[11] == 0x0F or entry[11] & 0x08 or not entry[11] & 0x10:
+          continue
+        child_cluster = (struct.unpack_from("<H", entry, 20)[0] << 16) | struct.unpack_from("<H", entry, 26)[0]
+        if child_cluster in seen_children or not (2 <= child_cluster <= max_cluster):
+          raise StorageError("virtual FAT32 root contains an invalid child directory")
+        seen_children.add(child_cluster)
+        child_offset = data_offset + (child_cluster - 2) * cluster_bytes
+        dot_entries = bytearray(_pread_exact(descriptor, 64, child_offset))
+        dot_cluster = (struct.unpack_from("<H", dot_entries, 20)[0] << 16) | struct.unpack_from("<H", dot_entries, 26)[0]
+        parent_cluster = (struct.unpack_from("<H", dot_entries, 52)[0] << 16) | struct.unpack_from("<H", dot_entries, 58)[0]
+        if dot_entries[0:11] != b".          " or dot_entries[32:43] != b"..         " or not (dot_entries[11] & 0x10 and dot_entries[43] & 0x10):
+          raise StorageError("virtual FAT32 child directory lacks valid dot entries")
+        if dot_cluster != child_cluster or parent_cluster not in (0, root_cluster):
+          raise StorageError("virtual FAT32 child directory has invalid dot clusters")
+        struct.pack_into("<H", dot_entries, 52, 0)
+        struct.pack_into("<H", dot_entries, 58, 0)
+        patches.append((child_offset + 32, bytes(dot_entries[32:64])))
+
+      if end_of_directory:
+        break
+      next_cluster = struct.unpack("<I", _pread_exact(descriptor, 4, fat_offset + cluster * 4))[0] & 0x0FFFFFFF
+      if next_cluster >= FAT32_END_OF_CHAIN:
+        break
+      if next_cluster in (0, 1, FAT32_BAD_CLUSTER):
+        raise StorageError("virtual FAT32 root directory has a broken FAT chain")
+      cluster = next_cluster
+
+    for offset, data in patches:
+      _pwrite_exact(descriptor, data, offset)
+    os.fsync(descriptor)
+    for offset, data in patches:
+      if _pread_exact(descriptor, len(data), offset) != data:
+        raise StorageError("virtual FAT32 metadata repair did not persist")
+  finally:
+    os.close(descriptor)
+
+
+def _entry_record(path: Path, relative_path: Path) -> EntryRecord:
+  _validate_portable_name(path.name)
+  metadata = path.lstat()
+  mode = metadata.st_mode
+  if stat.S_ISLNK(mode):
+    raise UnsafeTreeError(f"contains symbolic link: {relative_path}")
+  if not (stat.S_ISDIR(mode) or stat.S_ISREG(mode)):
+    raise UnsafeTreeError(f"contains non-regular entry: {relative_path}")
+  if path.name.endswith(".lock"):
+    raise UnsafeTreeError(f"contains active lock: {relative_path}")
+  # nbdkit 1.36's floppy plugin assigns zero-length files a free first cluster,
+  # producing a FAT chain that macOS fsck and other strict readers reject.
+  if stat.S_ISREG(mode) and metadata.st_size == 0:
+    raise UnsafeTreeError(f"contains empty file unsupported by nbdkit floppy: {relative_path}")
+  if stat.S_ISREG(mode) and metadata.st_size >= MAX_FAT_FILE_SIZE:
+    raise UnsafeTreeError(f"contains file too large for FAT32: {relative_path}")
+  return EntryRecord(
+    relative_path=relative_path,
+    is_directory=stat.S_ISDIR(mode),
+    device=metadata.st_dev,
+    inode=metadata.st_ino,
+    size=metadata.st_size,
+    mtime_ns=metadata.st_mtime_ns,
+  )
+
+
+def _chmod_directory(path: Path, mode: int) -> None:
+  """Change a real directory by descriptor, never following a symlink."""
+  if not hasattr(os, "O_DIRECTORY") or not hasattr(os, "O_NOFOLLOW"):
+    raise StorageError("secure directory chmod is unsupported on this platform")
+  descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW)
+  try:
+    if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
+      raise StorageError(f"managed path is not a directory: {path}")
+    os.fchmod(descriptor, mode)
+  finally:
+    os.close(descriptor)
+
+
+def _scan_tree(root: Path) -> tuple[EntryRecord, ...]:
+  root_metadata = root.lstat()
+  if not stat.S_ISDIR(root_metadata.st_mode) or stat.S_ISLNK(root_metadata.st_mode):
+    raise UnsafeTreeError("segment root is not a real directory")
+
+  records: list[EntryRecord] = []
+
+  def scan(directory: Path, relative_directory: Path) -> None:
+    try:
+      entries = sorted(os.scandir(directory), key=lambda entry: entry.name)
+    except OSError as exc:
+      raise UnsafeTreeError(f"cannot scan {relative_directory or Path('.')}: {exc}") from exc
+
+    for entry in entries:
+      relative_path = relative_directory / entry.name
+      path = directory / entry.name
+      try:
+        record = _entry_record(path, relative_path)
+      except OSError as exc:
+        raise UnsafeTreeError(f"cannot inspect {relative_path}: {exc}") from exc
+      records.append(record)
+      if record.is_directory:
+        scan(path, relative_path)
+
+  scan(root, Path())
+  return tuple(records)
+
+
+class SnapshotBuilder:
+  """Build and remove the one narrowly named directory this service owns."""
+
+  def __init__(
+    self,
+    source: str | os.PathLike[str],
+    snapshot: str | os.PathLike[str],
+    *,
+    wall_clock_ns: Callable[[], int] = time.time_ns,
+    stability_age_ns: int = DEFAULT_STABILITY_AGE_NS,
+  ):
+    source_path = Path(source)
+    snapshot_path = Path(snapshot)
+    if not source_path.is_absolute() or not snapshot_path.is_absolute():
+      raise StorageError("source and snapshot paths must be absolute")
+
+    # realdata is created by openpilot and may not exist when this boot service
+    # starts. Resolve as much as possible now, then validate it before building.
+    self.requested_source = source_path
+    self.source = source_path.resolve(strict=False)
+    self.requested_snapshot_parent = snapshot_path.parent
+    snapshot_parent = self.requested_snapshot_parent.resolve(strict=True)
+    self.snapshot = snapshot_parent / snapshot_path.name
+    if stability_age_ns <= 0:
+      raise StorageError("segment stability age must be positive")
+    self.wall_clock_ns = wall_clock_ns
+    self.stability_age_ns = stability_age_ns
+    self._validate_managed_path()
+
+  def _validate_managed_path(self) -> None:
+    if self.snapshot.name != MANAGED_SNAPSHOT_NAME:
+      raise StorageError(f"refusing unmanaged snapshot path (basename must be {MANAGED_SNAPSHOT_NAME!r})")
+    parent_metadata = self.snapshot.parent.lstat()
+    if not stat.S_ISDIR(parent_metadata.st_mode) or stat.S_ISLNK(parent_metadata.st_mode):
+      raise StorageError("snapshot parent must be a real directory")
+    if self.snapshot.parent == Path("/"):
+      raise StorageError("snapshot must not be placed directly below the filesystem root")
+    if self.requested_snapshot_parent.resolve(strict=True) != self.snapshot.parent:
+      raise StorageError("snapshot parent resolution changed after service start")
+    if self.source == self.snapshot or self.snapshot.is_relative_to(self.source) or self.source.is_relative_to(self.snapshot):
+      raise StorageError("source and snapshot trees must not contain each other")
+
+  def _validate_build_paths(self) -> None:
+    self._validate_managed_path()
+    requested_metadata = self.requested_source.lstat()
+    if stat.S_ISLNK(requested_metadata.st_mode):
+      raise StorageError("source path must not be a symbolic link")
+    if self.requested_source.resolve(strict=True) != self.source:
+      raise StorageError("source path resolution changed after service start")
+    source_metadata = self.source.lstat()
+    parent_metadata = self.snapshot.parent.lstat()
+    if not stat.S_ISDIR(source_metadata.st_mode) or stat.S_ISLNK(source_metadata.st_mode):
+      raise StorageError("source must be a real directory")
+    if source_metadata.st_dev != parent_metadata.st_dev:
+      raise StorageError("snapshot and source must be on the same filesystem")
+
+  def source_is_ready(self) -> bool:
+    try:
+      self._validate_build_paths()
+      return True
+    except FileNotFoundError:
+      return False
+
+  def _validate_existing_snapshot(self) -> None:
+    self._validate_managed_path()
+    try:
+      metadata = self.snapshot.lstat()
+    except FileNotFoundError:
+      return
+    if not stat.S_ISDIR(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+      raise StorageError("managed snapshot path exists but is not a real directory")
+    if os.path.ismount(self.snapshot):
+      raise StorageError("refusing to remove a mounted snapshot directory")
+
+    # Reject nested mounts before a bottom-up walk could cross into one. This
+    # check is deliberately separate from deletion so validation completes
+    # before the first unlink.
+    for directory, directory_names, _ in os.walk(self.snapshot, topdown=True, followlinks=False):
+      directory_path = Path(directory)
+      for directory_name in directory_names:
+        child = directory_path / directory_name
+        metadata = child.lstat()
+        if not stat.S_ISLNK(metadata.st_mode) and os.path.ismount(child):
+          raise StorageError(f"refusing to remove nested mount: {child}")
+
+  def _remove_snapshot_tree(self) -> None:
+    self._validate_existing_snapshot()
+    if not self.snapshot.exists():
+      return
+
+    for directory, directory_names, file_names in os.walk(self.snapshot, topdown=False, followlinks=False):
+      directory_path = Path(directory)
+      _chmod_directory(directory_path, 0o700)
+      for file_name in file_names:
+        (directory_path / file_name).unlink()
+      for directory_name in directory_names:
+        child = directory_path / directory_name
+        metadata = child.lstat()
+        if stat.S_ISLNK(metadata.st_mode):
+          child.unlink()
+        else:
+          _chmod_directory(child, 0o700)
+          child.rmdir()
+    self.snapshot.rmdir()
+
+  def cleanup(self) -> None:
+    self._remove_snapshot_tree()
+
+  def _candidate_segments(self) -> Iterator[Path]:
+    try:
+      top_entries = sorted(os.scandir(self.source), key=lambda entry: entry.name)
+    except OSError as exc:
+      raise StorageError(f"cannot list realdata: {exc}") from exc
+
+    for entry in top_entries:
+      entry_path = self.source / entry.name
+      try:
+        metadata = entry_path.lstat()
+      except OSError:
+        continue
+      if not stat.S_ISDIR(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+        continue
+
+      if SEGMENT_NAME_RE.fullmatch(entry.name):
+        yield entry_path
+
+  @staticmethod
+  def _make_directories(destination: Path, records: tuple[EntryRecord, ...]) -> None:
+    destination.mkdir(parents=True, mode=0o700)
+    for record in records:
+      if record.is_directory:
+        (destination / record.relative_path).mkdir(mode=0o700)
+
+  @staticmethod
+  def _link_files(source: Path, destination: Path, records: tuple[EntryRecord, ...]) -> None:
+    for record in records:
+      if record.is_directory:
+        continue
+      source_file = source / record.relative_path
+      destination_file = destination / record.relative_path
+      before = _entry_record(source_file, record.relative_path)
+      if before != record:
+        raise UnsafeTreeError(f"changed while snapshotting: {record.relative_path}")
+      os.link(source_file, destination_file, follow_symlinks=False)
+      linked_metadata = destination_file.lstat()
+      if not stat.S_ISREG(linked_metadata.st_mode) or linked_metadata.st_dev != record.device or linked_metadata.st_ino != record.inode:
+        raise UnsafeTreeError(f"hard-link verification failed: {record.relative_path}")
+
+  @staticmethod
+  def _freeze_directories(destination: Path) -> None:
+    directories = [Path(root) for root, _, _ in os.walk(destination, followlinks=False)]
+    for directory in reversed(directories):
+      _chmod_directory(directory, 0o555)
+
+  @staticmethod
+  def _remove_candidate(destination: Path) -> None:
+    if not destination.exists():
+      return
+    for root, directory_names, file_names in os.walk(destination, topdown=False, followlinks=False):
+      root_path = Path(root)
+      _chmod_directory(root_path, 0o700)
+      for file_name in file_names:
+        (root_path / file_name).unlink()
+      for directory_name in directory_names:
+        child = root_path / directory_name
+        if child.is_symlink():
+          child.unlink()
+        else:
+          _chmod_directory(child, 0o700)
+          child.rmdir()
+    destination.rmdir()
+
+  def build(self) -> SnapshotResult:
+    self._validate_build_paths()
+    source_before = self.source.lstat()
+    self._remove_snapshot_tree()
+    self.snapshot.mkdir(mode=0o700)
+    included: list[str] = []
+    excluded: list[tuple[str, str]] = []
+
+    try:
+      candidates: dict[str, list[tuple[str, Path]]] = {}
+      for source_segment in self._candidate_segments():
+        try:
+          destination_name = _portable_segment_name(source_segment.name)
+        except UnsafeTreeError as exc:
+          excluded.append((source_segment.name, str(exc)))
+          continue
+        collision_key = unicodedata.normalize("NFC", destination_name).casefold()
+        candidates.setdefault(collision_key, []).append((destination_name, source_segment))
+
+      for mapped_segments in candidates.values():
+        if len(mapped_segments) != 1:
+          reason = f"portable segment name collides as {mapped_segments[0][0]!r}"
+          excluded.extend((source_segment.name, reason) for _destination_name, source_segment in mapped_segments)
+          continue
+
+        destination_name, source_segment = mapped_segments[0]
+        relative_segment = Path(destination_name)
+        destination_segment = self.snapshot / relative_segment
+        try:
+          root_before = source_segment.lstat()
+          first_manifest = _scan_tree(source_segment)
+          newest_mtime_ns = max((root_before.st_mtime_ns, *(record.mtime_ns for record in first_manifest)))
+          if self.wall_clock_ns() - newest_mtime_ns < self.stability_age_ns:
+            raise UnsafeTreeError("segment tree is too recent to be stable")
+          self._make_directories(destination_segment, first_manifest)
+          self._link_files(source_segment, destination_segment, first_manifest)
+          second_manifest = _scan_tree(source_segment)
+          if second_manifest != first_manifest:
+            raise UnsafeTreeError("tree changed while snapshotting")
+          root_after = source_segment.lstat()
+          if root_after.st_dev != root_before.st_dev or root_after.st_ino != root_before.st_ino or root_after.st_mtime_ns != root_before.st_mtime_ns:
+            raise UnsafeTreeError("segment directory changed while snapshotting")
+          included.append(str(relative_segment))
+        except (OSError, UnsafeTreeError) as exc:
+          self._remove_candidate(destination_segment)
+          excluded.append((str(relative_segment), str(exc)))
+
+      # Remove any empty directory left by a rejected candidate.
+      for root, _, _ in os.walk(self.snapshot, topdown=False, followlinks=False):
+        root_path = Path(root)
+        if root_path != self.snapshot and not any(root_path.iterdir()):
+          root_path.rmdir()
+      source_after = self.source.lstat()
+      if source_after.st_dev != source_before.st_dev or source_after.st_ino != source_before.st_ino:
+        raise UnsafeTreeError("realdata root changed while snapshotting")
+      self._freeze_directories(self.snapshot)
+    except BaseException:
+      self._remove_snapshot_tree()
+      raise
+
+    return SnapshotResult(tuple(included), tuple(excluded))
+
+
+class StorageManager:
+  DISCONNECTED_UDC_STATES = frozenset({"not attached"})
+  CONFIGURED_UDC_STATES = frozenset({"configured", "suspended"})
+
+  def __init__(
+    self,
+    *,
+    source: str | os.PathLike[str],
+    snapshot: str | os.PathLike[str],
+    mount: str | os.PathLike[str],
+    lun: str | os.PathLike[str],
+    udc_state: str | os.PathLike[str],
+    gadget_lock: str | os.PathLike[str],
+    gadget_helper: str | os.PathLike[str] = "/usr/comma/usb_gadget.sh",
+    ready_timeout: float = 20.0,
+    stop_timeout: float = 5.0,
+    poll_interval: float = 0.1,
+    process_factory: Callable[..., Any] = subprocess.Popen,
+    command_runner: Callable[..., Any] = subprocess.run,
+    clock: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+    snapshot_wall_clock_ns: Callable[[], int] = time.time_ns,
+    stability_age_ns: int = DEFAULT_STABILITY_AGE_NS,
+    image_repairer: Callable[[Path], None] = _repair_fat32_image,
+    filesystem_stats: Callable[[Path], Any] = os.statvfs,
+  ):
+    self.snapshot_builder = SnapshotBuilder(
+      source,
+      snapshot,
+      wall_clock_ns=snapshot_wall_clock_ns,
+      stability_age_ns=stability_age_ns,
+    )
+    self.mount = Path(mount)
+    self.lun = Path(lun)
+    self.udc_state = Path(udc_state)
+    self.gadget_lock = Path(gadget_lock)
+    self.gadget_helper = Path(gadget_helper)
+    if not self.mount.is_absolute() or not self.lun.is_absolute() or not self.udc_state.is_absolute():
+      raise StorageError("mount, LUN, and UDC state paths must be absolute")
+    if self.mount.name != MANAGED_MOUNT_NAME or self.mount.parent.name != MANAGED_MOUNT_DIRECTORY:
+      raise StorageError(f"refusing unmanaged FUSE path (expected .../{MANAGED_MOUNT_DIRECTORY}/{MANAGED_MOUNT_NAME})")
+    if self.lun.name != "file" or self.lun.parent.name != "lun.0":
+      raise StorageError("refusing unexpected configfs LUN path")
+    if not self.gadget_lock.is_absolute():
+      raise StorageError("gadget lock path must be absolute")
+    if not self.gadget_helper.is_absolute():
+      raise StorageError("gadget helper path must be absolute")
+    if min(ready_timeout, stop_timeout, poll_interval) <= 0:
+      raise StorageError("timeouts and poll interval must be positive")
+
+    self.ready_timeout = ready_timeout
+    self.stop_timeout = stop_timeout
+    self.poll_interval = poll_interval
+    self.process_factory = process_factory
+    self.command_runner = command_runner
+    self.clock = clock
+    self.sleep = sleep
+    self.image_repairer = image_repairer
+    self.filesystem_stats = filesystem_stats
+    # Directory/filename mode mounts FUSE over mount.parent, hiding everything
+    # in it. Keep readiness state next to (not inside) that mount directory.
+    self.pidfile = self.mount.parent.with_suffix(".pid")
+    self.process: Any | None = None
+    self.export_started = False
+    self.forced_unbound = False
+
+  @contextmanager
+  def _gadget_locked(self) -> Iterator[None]:
+    flags = os.O_RDWR | os.O_CREAT | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+      flags |= os.O_NOFOLLOW
+    descriptor = os.open(self.gadget_lock, flags, 0o600)
+    try:
+      if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+        raise StorageError("gadget lock is not a regular file")
+      fcntl.flock(descriptor, fcntl.LOCK_EX)
+      yield
+    finally:
+      fcntl.flock(descriptor, fcntl.LOCK_UN)
+      os.close(descriptor)
+
+  def _open_lun(self, flags: int) -> int:
+    if hasattr(os, "O_NOFOLLOW"):
+      flags |= os.O_NOFOLLOW
+    try:
+      metadata = self.lun.lstat()
+    except FileNotFoundError as exc:
+      raise LunUnavailableError("configfs LUN file does not exist") from exc
+    if not stat.S_ISREG(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+      raise StorageError("configfs LUN path is not a regular file")
+    return os.open(self.lun, flags | os.O_CLOEXEC)
+
+  def _read_lun_unlocked(self) -> str:
+    descriptor = self._open_lun(os.O_RDONLY)
+    try:
+      return os.read(descriptor, 4096).decode("utf-8", errors="strict").strip()
+    finally:
+      os.close(descriptor)
+
+  def _write_lun_unlocked(self, value: str) -> None:
+    descriptor = self._open_lun(os.O_WRONLY | os.O_TRUNC)
+    try:
+      data = f"{value}\n".encode()
+      if os.write(descriptor, data) != len(data):
+        raise StorageError("short write to configfs LUN")
+    finally:
+      os.close(descriptor)
+
+  def _read_lun(self) -> str:
+    with self._gadget_locked():
+      return self._read_lun_unlocked()
+
+  def _validate_lun_policy_unlocked(self) -> None:
+    for attribute in ("ro", "removable"):
+      attribute_path = self.lun.parent / attribute
+      flags = os.O_RDONLY | os.O_CLOEXEC
+      if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+      try:
+        metadata = attribute_path.lstat()
+        if not stat.S_ISREG(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+          raise StorageError(f"USB LUN {attribute} attribute is not a regular file")
+        descriptor = os.open(attribute_path, flags)
+      except FileNotFoundError as exc:
+        raise LunUnavailableError(f"USB LUN {attribute} attribute does not exist") from exc
+      try:
+        if os.read(descriptor, 32).decode("ascii", errors="strict").strip() != "1":
+          raise StorageError(f"refusing USB LUN with {attribute}=0")
+      finally:
+        os.close(descriptor)
+
+  def _set_lun(self) -> None:
+    with self._gadget_locked():
+      self._validate_lun_policy_unlocked()
+      current = self._read_lun_unlocked()
+      if current not in ("", str(self.mount)):
+        raise StorageError(f"LUN is owned by another backing file: {current}")
+      self._write_lun_unlocked(str(self.mount))
+      if self._read_lun_unlocked() != str(self.mount):
+        raise StorageError("configfs LUN did not retain the requested backing file")
+      self._validate_lun_policy_unlocked()
+
+  def _clear_lun(self) -> None:
+    deadline = self.clock() + self.stop_timeout
+    while True:
+      try:
+        with self._gadget_locked():
+          current = self._read_lun_unlocked()
+          if current == str(self.mount):
+            self._write_lun_unlocked("")
+            if self._read_lun_unlocked() == "":
+              return
+          elif current:
+            # Never clear a backing file installed by a different manager.
+            raise ForeignLunError(f"LUN is owned by another backing file: {current}")
+          else:
+            return
+      except LunUnavailableError:
+        # Configfs may disappear after UDC teardown. With no LUN attribute,
+        # nothing can still hold our FUSE file as a mass-storage backing file.
+        return
+      except OSError as exc:
+        if exc.errno not in (errno.EAGAIN, errno.EBUSY):
+          raise
+      if self.clock() >= deadline:
+        raise LunBusyError("timed out releasing the configfs LUN")
+      self.sleep(self.poll_interval)
+
+  def _read_udc_state(self) -> str:
+    try:
+      metadata = self.udc_state.lstat()
+      if not stat.S_ISREG(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+        raise StorageError("UDC state path is not a regular file")
+      return self.udc_state.read_text().strip().lower()
+    except FileNotFoundError as exc:
+      raise UdcUnavailableError("UDC state is not available") from exc
+    except OSError as exc:
+      raise StorageError(f"cannot read UDC state: {exc}") from exc
+
+  def _ensure_child_running(self) -> None:
+    if self.process is None:
+      raise StorageError("nbdfuse was not started")
+    return_code = self.process.poll()
+    if return_code is not None:
+      raise StorageError(f"nbdfuse exited unexpectedly with status {return_code}")
+
+  def _prepare_mount(self) -> None:
+    if not self.mount.parent.exists():
+      self.mount.parent.mkdir(parents=True, mode=0o700)
+    parent_metadata = self.mount.parent.lstat()
+    if not stat.S_ISDIR(parent_metadata.st_mode) or stat.S_ISLNK(parent_metadata.st_mode):
+      raise StorageError("nbdfuse mount parent is not a real directory")
+    if os.path.ismount(self.mount.parent):
+      raise StorageError("refusing to replace an active nbdfuse mount")
+    try:
+      mount_metadata = self.mount.lstat()
+    except FileNotFoundError:
+      pass
+    else:
+      if not stat.S_ISREG(mount_metadata.st_mode) or stat.S_ISLNK(mount_metadata.st_mode):
+        raise StorageError("nbdfuse output path is not a safe stale file")
+      # nbdfuse creates this virtual file. A regular file visible while the
+      # parent is not mounted is a stale, exactly scoped artifact.
+      self.mount.unlink()
+    try:
+      pid_metadata = self.pidfile.lstat()
+    except FileNotFoundError:
+      pass
+    else:
+      if not stat.S_ISREG(pid_metadata.st_mode) or stat.S_ISLNK(pid_metadata.st_mode):
+        raise StorageError("nbdfuse pidfile path is unsafe")
+      self.pidfile.unlink()
+
+  def _start_export(self) -> None:
+    self._prepare_mount()
+    disk_size, size_argument = _nbdkit_layout(self.snapshot_builder.snapshot)
+    command = [
+      "/usr/bin/nbdfuse",
+      "-P",
+      str(self.pidfile),
+      str(self.mount),
+      "--command",
+      "/usr/bin/nbdkit",
+      "-s",
+      "--exit-with-parent",
+      "--filter=cow",
+      "floppy",
+      f"dir={self.snapshot_builder.snapshot}",
+      "label=COMMA",
+    ]
+    if size_argument is not None:
+      command.append(f"size={size_argument}")
+    environment = os.environ.copy()
+    # nbdkit-cow creates an unlinked sparse overlay. Keep its few repaired
+    # blocks on userdata rather than AGNOS's 128 MiB /var tmpfs.
+    environment["TMPDIR"] = str(self.snapshot_builder.snapshot.parent)
+    self.process = self.process_factory(command, close_fds=True, env=environment)
+    self.export_started = True
+
+    deadline = self.clock() + self.ready_timeout
+    while self.clock() < deadline:
+      self._ensure_child_running()
+      try:
+        pid_text = self.pidfile.read_text().strip()
+        mount_metadata = self.mount.lstat()
+        ready = int(pid_text) == self.process.pid and stat.S_ISREG(mount_metadata.st_mode) and not stat.S_ISLNK(mount_metadata.st_mode)
+        ready = ready and mount_metadata.st_size == disk_size
+      except (FileNotFoundError, OSError, ValueError):
+        ready = False
+      if ready:
+        self.image_repairer(self.mount)
+        return
+      self.sleep(self.poll_interval)
+    raise StorageError("timed out waiting for nbdfuse readiness")
+
+  def _wait_for_configured(self, stop_event: threading.Event) -> bool:
+    while not stop_event.is_set():
+      try:
+        if self._read_udc_state() in self.CONFIGURED_UDC_STATES:
+          return True
+      except UdcUnavailableError:
+        # The UDC may appear after this boot service starts.
+        pass
+      self.sleep(self.poll_interval)
+    return False
+
+  def _wait_for_source_while_attached(self, stop_event: threading.Event) -> bool:
+    while not stop_event.is_set():
+      try:
+        state = self._read_udc_state()
+      except UdcUnavailableError:
+        return False
+      if state in self.DISCONNECTED_UDC_STATES:
+        return False
+      if state in self.CONFIGURED_UDC_STATES and self.snapshot_builder.source_is_ready() and self._has_export_capacity():
+        return True
+      self.sleep(self.poll_interval)
+    return False
+
+  def _has_export_capacity(self) -> bool:
+    try:
+      filesystem = self.filesystem_stats(self.snapshot_builder.source)
+      if filesystem.f_blocks <= 0 or filesystem.f_frsize <= 0:
+        return False
+      available_bytes = filesystem.f_bavail * filesystem.f_frsize
+      available_percent = 100.0 * filesystem.f_bavail / filesystem.f_blocks
+      return available_bytes > MIN_FREE_BYTES and available_percent > MIN_FREE_PERCENT
+    except OSError:
+      return False
+
+  def _wait_for_physical_detach(self, stop_event: threading.Event) -> bool:
+    while not stop_event.is_set():
+      try:
+        if self._read_udc_state() in self.DISCONNECTED_UDC_STATES:
+          return True
+      except UdcUnavailableError:
+        # A disappearing UDC is also a physical/configfs detachment.
+        return True
+      self.sleep(self.poll_interval)
+    return False
+
+  def monitor(self, stop_event: threading.Event) -> SessionEnd:
+    while not stop_event.is_set():
+      self._ensure_child_running()
+      try:
+        lun = self._read_lun()
+      except LunUnavailableError:
+        return SessionEnd.DETACHED
+      if lun != str(self.mount):
+        return SessionEnd.EJECTED
+      try:
+        state = self._read_udc_state()
+      except UdcUnavailableError:
+        return SessionEnd.DETACHED
+      if state in self.DISCONNECTED_UDC_STATES:
+        return SessionEnd.DETACHED
+      if not self._has_export_capacity():
+        return SessionEnd.LOW_SPACE
+      self.sleep(self.poll_interval)
+    return SessionEnd.STOPPED
+
+  def _run_gadget_helper(self, action: str) -> None:
+    if action not in ("bind", "unbind"):
+      raise StorageError(f"invalid gadget helper action: {action}")
+    # usb_gadget.sh takes the shared flock itself. Never invoke it from within
+    # _gadget_locked(), or both processes would deadlock.
+    result = self.command_runner(
+      [str(self.gadget_helper), action],
+      check=False,
+      timeout=self.stop_timeout,
+    )
+    if getattr(result, "returncode", 0) != 0:
+      raise StorageError(f"gadget helper {action} failed with status {result.returncode}")
+
+  def _release_lun_with_fallback(self) -> None:
+    try:
+      self._clear_lun()
+    except LunBusyError:
+      LOG.warning("host prevented media removal; forcing a bounded UDC unbind")
+      self._run_gadget_helper("unbind")
+      self.forced_unbound = True
+      self._clear_lun()
+
+  def _unmount(self) -> None:
+    if not self.export_started:
+      return
+    result = self.command_runner(
+      ["/usr/bin/fusermount3", "-u", str(self.mount.parent)],
+      check=False,
+      timeout=self.stop_timeout,
+    )
+    if getattr(result, "returncode", 0) != 0:
+      raise StorageError(f"fusermount3 failed with status {result.returncode}")
+
+  def _stop_child(self) -> None:
+    if self.process is None:
+      return
+    process = self.process
+    try:
+      process.wait(timeout=self.stop_timeout)
+    except subprocess.TimeoutExpired:
+      process.terminate()
+      try:
+        process.wait(timeout=self.stop_timeout)
+      except subprocess.TimeoutExpired:
+        process.kill()
+        try:
+          process.wait(timeout=self.stop_timeout)
+        except subprocess.TimeoutExpired as exc:
+          raise StorageError("nbdfuse did not stop after SIGKILL") from exc
+    self.process = None
+    self.export_started = False
+    try:
+      self.pidfile.unlink()
+    except FileNotFoundError:
+      pass
+
+  def teardown(self, *, rebind: bool = True) -> None:
+    # This order is a safety invariant: configfs must release the backing file
+    # before FUSE disappears, and the hard-link namespace must outlive nbdkit.
+    try:
+      self._release_lun_with_fallback()
+    except BaseException as exc:
+      # If configfs still owns our path, tearing down FUSE would leave the USB
+      # function backed by a disappearing file. Keep the read-only export and
+      # snapshot alive; UDC orchestration can unbind and retry this service.
+      raise StorageError("refusing to tear down an attached LUN") from exc
+    # Each operation is intentionally gated on the previous one succeeding.
+    # A failed unmount or child stop leaves all later backing state intact.
+    self._unmount()
+    self._stop_child()
+    self.snapshot_builder.cleanup()
+
+    if self.forced_unbound and rebind:
+      self._run_gadget_helper("bind")
+      self.forced_unbound = False
+
+  def run(self, stop_event: threading.Event) -> int:
+    completed_sessions = 0
+    # Recover a stale configfs reference before accepting any host. This never
+    # scans or pins realdata and may safely force an unbind if PREVENT is stale.
+    self._release_lun_with_fallback()
+    # ExecStartPre attempts a lazy stale unmount, but its failure is ignored so
+    # boot can proceed. Verify it is truly gone and remove only our exact stale
+    # virtual-file and pid artifacts before deleting the snapshot they used.
+    self._prepare_mount()
+    self.snapshot_builder.cleanup()
+    if self.forced_unbound:
+      self._run_gadget_helper("bind")
+      self.forced_unbound = False
+
+    while self._wait_for_configured(stop_event):
+      if not self._wait_for_source_while_attached(stop_event):
+        continue
+
+      snapshot: SnapshotResult | None = None
+      end = SessionEnd.DETACHED
+      media_attached = False
+      failure: BaseException | None = None
+      try:
+        snapshot = self.snapshot_builder.build()
+        if stop_event.is_set():
+          end = SessionEnd.STOPPED
+        elif self._read_udc_state() not in self.CONFIGURED_UDC_STATES:
+          end = SessionEnd.DETACHED
+        else:
+          self._start_export()
+          self._set_lun()
+          media_attached = True
+          end = self.monitor(stop_event)
+      except BaseException as exc:
+        failure = exc
+        raise
+      finally:
+        try:
+          self.teardown(rebind=not stop_event.is_set())
+        except BaseException:
+          if failure is None:
+            raise
+          LOG.exception("teardown also failed after storage session error")
+
+      if media_attached and snapshot is not None:
+        completed_sessions += 1
+        LOG.info(
+          "session %s: exported %d segments, excluded %d",
+          end,
+          len(snapshot.included),
+          len(snapshot.excluded),
+        )
+        for segment, reason in snapshot.excluded:
+          LOG.warning("excluded %s: %s", segment, reason)
+
+      if stop_event.is_set() or end == SessionEnd.STOPPED:
+        break
+      if end in (SessionEnd.EJECTED, SessionEnd.LOW_SPACE) and not self._wait_for_physical_detach(stop_event):
+        break
+
+    return completed_sessions
+
+
+def _build_parser() -> argparse.ArgumentParser:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument("--source", default="/data/media/0/realdata")
+  parser.add_argument("--snapshot", default="/data/tmp/usb-storage-snapshot")
+  parser.add_argument("--mount", default="/run/usb-storage/footage.img")
+  parser.add_argument(
+    "--lun",
+    default="/config/usb_gadget/g1/functions/mass_storage.0/lun.0/file",
+  )
+  parser.add_argument("--udc-state", default="/sys/class/udc/a600000.dwc3/state")
+  parser.add_argument("--gadget-lock", default="/run/lock/comma-usb-gadget.lock")
+  parser.add_argument("--gadget-helper", default="/usr/comma/usb_gadget.sh")
+  parser.add_argument("--ready-timeout", type=float, default=20.0)
+  parser.add_argument("--stop-timeout", type=float, default=5.0)
+  return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+  logging.basicConfig(level=logging.INFO, format="%(name)s: %(levelname)s: %(message)s")
+  arguments = _build_parser().parse_args(argv)
+  stop_event = threading.Event()
+
+  def request_stop(_signal_number: int, _frame: Any) -> None:
+    stop_event.set()
+
+  previous_handlers = {handled_signal: signal.signal(handled_signal, request_stop) for handled_signal in (signal.SIGINT, signal.SIGTERM)}
+  try:
+    manager = StorageManager(
+      source=arguments.source,
+      snapshot=arguments.snapshot,
+      mount=arguments.mount,
+      lun=arguments.lun,
+      udc_state=arguments.udc_state,
+      gadget_lock=arguments.gadget_lock,
+      gadget_helper=arguments.gadget_helper,
+      ready_timeout=arguments.ready_timeout,
+      stop_timeout=arguments.stop_timeout,
+    )
+    completed_sessions = manager.run(stop_event)
+    LOG.info("stopped after %d completed storage sessions", completed_sessions)
+    return 0
+  except StorageError:
+    LOG.exception("USB storage session failed safely")
+    return 1
+  finally:
+    for handled_signal, previous_handler in previous_handlers.items():
+      signal.signal(handled_signal, previous_handler)
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/userspace/root/usr/comma/usb_storage.py
+++ b/userspace/root/usr/comma/usb_storage.py
@@ -38,6 +38,10 @@ MANAGED_MOUNT_NAME = "footage.img"
 # nbdkit-floppy rejects files whose size cannot fit in its uint32_t field.
 MAX_FAT_FILE_SIZE = (1 << 32) - 1
 DEFAULT_STABILITY_AGE_NS = 2_000_000_000
+# A configfs unbind/rebind can briefly report "not attached" even though the
+# cable never moved. Require a stable disconnect before starting a new session
+# so a persistent exporter failure cannot flap the composite USB device.
+PHYSICAL_DETACH_DEBOUNCE_SECONDS = 2.0
 # Match loggerd's current deleter safety floor. A connected hard-link snapshot
 # can pin otherwise deleted footage, so release it as soon as either limit is
 # reached rather than letting logging exhaust userdata.
@@ -1020,14 +1024,38 @@ class StorageManager:
     except OSError:
       return False
 
-  def _wait_for_physical_detach(self, stop_event: threading.Event) -> bool:
+  def _wait_for_physical_detach(
+    self,
+    stop_event: threading.Event,
+    *,
+    require_reconfigured: bool = False,
+  ) -> bool:
+    detached_since: float | None = None
+    reconfigured = not require_reconfigured
     while not stop_event.is_set():
       try:
-        if self._read_udc_state() in self.DISCONNECTED_UDC_STATES:
-          return True
+        state = self._read_udc_state()
+        detached = state in self.DISCONNECTED_UDC_STATES
       except UdcUnavailableError:
         # A disappearing UDC is also a physical/configfs detachment.
-        return True
+        state = None
+        detached = True
+
+      now = self.clock()
+      if not reconfigured:
+        # When teardown had to unbind and reconstruct the gadget, even a long
+        # "not attached" interval may only be slow host re-enumeration. Arm
+        # physical-detach detection only after that rebind reaches a configured
+        # state; the next stable disconnect is then unambiguous.
+        reconfigured = state in self.CONFIGURED_UDC_STATES
+        detached_since = None
+      elif detached:
+        if detached_since is None:
+          detached_since = now
+        elif now - detached_since >= PHYSICAL_DETACH_DEBOUNCE_SECONDS:
+          return True
+      else:
+        detached_since = None
       self.sleep(self.idle_poll_interval)
     return False
 
@@ -1052,7 +1080,7 @@ class StorageManager:
     return SessionEnd.STOPPED
 
   def _run_gadget_helper(self, action: str) -> None:
-    if action not in ("bind", "unbind"):
+    if action not in ("unbind", "ensure-requested-personality"):
       raise StorageError(f"invalid gadget helper action: {action}")
     # usb_gadget.sh takes the shared flock itself. Never invoke it from within
     # _gadget_locked(), or both processes would deadlock.
@@ -1107,7 +1135,8 @@ class StorageManager:
     except FileNotFoundError:
       pass
 
-  def teardown(self, *, rebind: bool = True) -> None:
+  def teardown(self, *, rebind: bool = True) -> bool:
+    """Release session state and report whether the gadget was self-rebound."""
     # This order is a safety invariant: configfs must release the backing file
     # before FUSE disappears, and the hard-link namespace must outlive nbdkit.
     try:
@@ -1124,8 +1153,14 @@ class StorageManager:
     self.snapshot_builder.cleanup()
 
     if self.forced_unbound and rebind:
-      self._run_gadget_helper("bind")
+      # Another serialized gadget transition may have failed after changing
+      # descriptors or links while this manager was cleaning up. Reconstruct
+      # the complete requested personality rather than raw-binding whatever
+      # partial configfs state happens to remain.
+      self._run_gadget_helper("ensure-requested-personality")
       self.forced_unbound = False
+      return True
+    return False
 
   def run(self, stop_event: threading.Event) -> int:
     completed_sessions = 0
@@ -1138,7 +1173,7 @@ class StorageManager:
     self._prepare_mount()
     self.snapshot_builder.cleanup()
     if self.forced_unbound:
-      self._run_gadget_helper("bind")
+      self._run_gadget_helper("ensure-requested-personality")
       self.forced_unbound = False
 
     while self._wait_for_configured(stop_event):
@@ -1148,7 +1183,8 @@ class StorageManager:
       snapshot: SnapshotResult | None = None
       end = SessionEnd.DETACHED
       media_attached = False
-      failure: BaseException | None = None
+      failure: Exception | None = None
+      self_rebound = False
       try:
         snapshot = self.snapshot_builder.build()
         if stop_event.is_set():
@@ -1160,16 +1196,25 @@ class StorageManager:
           self._set_lun()
           media_attached = True
           end = self.monitor(stop_event)
-      except BaseException as exc:
+      except Exception as exc:
         failure = exc
-        raise
+        LOG.exception("USB storage session failed safely; waiting for physical detach before retry")
       finally:
         try:
-          self.teardown(rebind=not stop_event.is_set())
-        except BaseException:
+          self_rebound = self.teardown(rebind=not stop_event.is_set())
+        except BaseException as teardown_failure:
           if failure is None:
             raise
           LOG.exception("teardown also failed after storage session error")
+          # An incomplete teardown may leave configfs referencing the export.
+          # Exit so systemd's stop wrapper can force the gadget safe instead
+          # of continuing with uncertain backing-file ownership.
+          raise teardown_failure from failure
+
+      if failure is not None:
+        if not self._wait_for_physical_detach(stop_event, require_reconfigured=self_rebound):
+          break
+        continue
 
       if media_attached and snapshot is not None:
         completed_sessions += 1

--- a/userspace/root/usr/lib/systemd/system/usb-storage.service
+++ b/userspace/root/usr/lib/systemd/system/usb-storage.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Read-only USB footage storage
-Requires=comma-init.service
+Requires=comma-init.service adb-param-watcher.service
 After=comma-init.service adb-param-watcher.service
 
 [Service]
@@ -8,7 +8,7 @@ Type=simple
 User=root
 RuntimeDirectory=usb-storage
 RuntimeDirectoryMode=0700
-ExecStartPre=/usr/comma/set_adb.sh
+ExecStartPre=/usr/comma/usb_gadget.sh prepare-storage-start
 ExecStartPre=-/usr/bin/fusermount3 -uz /run/usb-storage
 ExecStart=/usr/bin/python3 -u /usr/comma/usb_storage.py \
   --source /data/media/0/realdata \

--- a/userspace/root/usr/lib/systemd/system/usb-storage.service
+++ b/userspace/root/usr/lib/systemd/system/usb-storage.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=Read-only USB footage storage
+Requires=comma-init.service
+After=comma-init.service adb-param-watcher.service
+
+[Service]
+Type=simple
+User=root
+RuntimeDirectory=usb-storage
+RuntimeDirectoryMode=0700
+ExecStartPre=/usr/comma/set_adb.sh
+ExecStartPre=-/usr/bin/fusermount3 -uz /run/usb-storage
+ExecStart=/usr/bin/python3 -u /usr/comma/usb_storage.py \
+  --source /data/media/0/realdata \
+  --snapshot /data/tmp/usb-storage-snapshot \
+  --mount /run/usb-storage/footage.img \
+  --lun /config/usb_gadget/g1/functions/mass_storage.0/lun.0/file \
+  --udc-state /sys/class/udc/a600000.dwc3/state \
+  --gadget-lock /run/lock/comma-usb-gadget.lock \
+  --gadget-helper /usr/comma/usb_gadget.sh
+ExecStop=/usr/comma/stop_usb_storage.sh $MAINPID
+KillSignal=SIGTERM
+KillMode=control-group
+TimeoutStopSec=45
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/userspace/root/usr/lib/systemd/system/usb-storage.service
+++ b/userspace/root/usr/lib/systemd/system/usb-storage.service
@@ -19,6 +19,7 @@ ExecStart=/usr/bin/python3 -u /usr/comma/usb_storage.py \
   --gadget-lock /run/lock/comma-usb-gadget.lock \
   --gadget-helper /usr/comma/usb_gadget.sh
 ExecStop=/usr/comma/stop_usb_storage.sh $MAINPID
+ExecStopPost=/usr/comma/cleanup_usb_storage.sh
 KillSignal=SIGTERM
 KillMode=control-group
 TimeoutStopSec=45

--- a/userspace/root/usr/lib/systemd/system/usb-storage.service
+++ b/userspace/root/usr/lib/systemd/system/usb-storage.service
@@ -24,6 +24,8 @@ KillMode=control-group
 TimeoutStopSec=45
 Restart=on-failure
 RestartSec=5
+RestartSteps=5
+RestartMaxDelaySec=5min
 
 [Install]
 WantedBy=multi-user.target

--- a/userspace/services.sh
+++ b/userspace/services.sh
@@ -17,6 +17,7 @@ systemctl enable logrotate-hourly.timer
 systemctl enable avahi-daemon
 systemctl enable avahi-ssh-publish.service
 systemctl enable tftp_server.service
+systemctl enable usb-storage.service
 
 # Disable SSH by default
 systemctl disable ssh

--- a/userspace/tests/integration_usb_storage_nbdkit.py
+++ b/userspace/tests/integration_usb_storage_nbdkit.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Exercise the installed Noble nbdkit/FAT tools against production code."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+
+COMMA_DIR = Path(__file__).parents[1] / "root" / "usr" / "comma"
+SPEC = importlib.util.spec_from_file_location("usb_storage", COMMA_DIR / "usb_storage.py")
+if SPEC is None or SPEC.loader is None:
+  raise RuntimeError("cannot load usb_storage.py")
+usb_storage = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = usb_storage
+SPEC.loader.exec_module(usb_storage)
+
+REQUIRED_TOOLS = ("nbdkit", "nbdcopy", "nbdinfo", "fsck.fat", "mdir", "mcopy", "dd")
+
+
+def require_tools() -> None:
+  missing = [tool for tool in REQUIRED_TOOLS if shutil.which(tool) is None]
+  if missing:
+    raise RuntimeError(f"missing integration-test tools: {', '.join(missing)}")
+
+
+def build_snapshot(root: Path, *, segment_name: str, payload_size: int) -> tuple[Path, str, bytes | None]:
+  source = root / "realdata"
+  source.mkdir(parents=True)
+  segment = source / segment_name
+  segment.mkdir()
+  payload = segment / "fcamera.hevc"
+  expected: bytes | None = None
+  if payload_size <= 1024 * 1024:
+    expected = (b"comma USB storage integration\x00\xff" * 64)[:payload_size]
+    payload.write_bytes(expected)
+  else:
+    with payload.open("wb") as stream:
+      stream.truncate(payload_size)
+
+  snapshot = root / usb_storage.MANAGED_SNAPSHOT_NAME
+  result = usb_storage.SnapshotBuilder(
+    source,
+    snapshot,
+    wall_clock_ns=lambda: time.time_ns() + 10 * usb_storage.DEFAULT_STABILITY_AGE_NS,
+  ).build()
+  if len(result.included) != 1 or result.excluded:
+    raise RuntimeError(f"unexpected snapshot result: {result}")
+  return snapshot, result.included[0], expected
+
+
+def run_small_image_check(root: Path) -> None:
+  small_root = root / "small"
+  small_root.mkdir()
+  snapshot, exported_segment, expected = build_snapshot(
+    small_root,
+    segment_name="a2a0ccea32023010|2026-08-23--12-34-56--0",
+    payload_size=2048,
+  )
+  if expected is None:
+    raise RuntimeError("small fixture was not materialized")
+
+  disk = small_root / "disk.img"
+  environment = os.environ.copy()
+  environment.update({"TMPDIR": str(small_root), "OUTPUT_IMAGE": str(disk)})
+  subprocess.run(
+    [
+      "/usr/bin/nbdkit",
+      "--filter=cow",
+      "floppy",
+      f"dir={snapshot}",
+      "label=COMMA",
+      f"size={usb_storage.MIN_COMPATIBLE_DISK_SIZE}",
+      "--run",
+      'exec /usr/bin/nbdcopy --sparse=1048576 "$uri" "$OUTPUT_IMAGE"',
+    ],
+    check=True,
+    env=environment,
+  )
+  expected_size, _size_argument = usb_storage._nbdkit_layout(snapshot)
+  if disk.stat().st_size != expected_size:
+    raise RuntimeError("nbdkit image size differs from the production layout")
+
+  usb_storage._repair_fat32_image(disk)
+  partition = small_root / "partition.img"
+  subprocess.run(
+    ["dd", f"if={disk}", f"of={partition}", "bs=1M", "skip=1", "conv=sparse", "status=none"],
+    check=True,
+  )
+  subprocess.run(["fsck.fat", "-n", "-v", str(partition)], check=True)
+
+  offset_image = f"{disk}@@1048576"
+  listing = subprocess.run(["mdir", "-i", offset_image, "::"], check=True, capture_output=True, text=True)
+  if exported_segment not in listing.stdout:
+    raise RuntimeError("mtools did not preserve the exported segment name")
+  extracted = small_root / "extracted.hevc"
+  subprocess.run(
+    ["mcopy", "-i", offset_image, f"::/{exported_segment}/fcamera.hevc", str(extracted)],
+    check=True,
+  )
+  if extracted.read_bytes() != expected:
+    raise RuntimeError("mtools extraction did not preserve fixture bytes")
+
+
+def run_natural_size_check(root: Path) -> None:
+  large_root = root / "natural"
+  large_root.mkdir()
+  # Root directory + segment directory consume two clusters. The sparse file
+  # fills the rest of the conservative FAT32 boundary exactly.
+  payload_size = (usb_storage.FAT32_COMPATIBLE_DATA_CLUSTERS - 2) * usb_storage.FAT_CLUSTER_SIZE
+  snapshot, _exported_segment, _expected = build_snapshot(
+    large_root,
+    segment_name="00000001--abc123def0--0",
+    payload_size=payload_size,
+  )
+  expected_size, size_argument = usb_storage._nbdkit_layout(snapshot)
+  if size_argument is not None or expected_size != usb_storage.MIN_COMPATIBLE_DISK_SIZE:
+    raise RuntimeError("natural-size fixture did not hit the exact unpadded boundary")
+
+  environment = os.environ.copy()
+  environment.update({"TMPDIR": str(large_root), "EXPECTED_SIZE": str(expected_size)})
+  subprocess.run(
+    [
+      "/usr/bin/nbdkit",
+      "--filter=cow",
+      "floppy",
+      f"dir={snapshot}",
+      "label=COMMA",
+      "--run",
+      'test "$(/usr/bin/nbdinfo --size "$uri")" = "$EXPECTED_SIZE"',
+    ],
+    check=True,
+    env=environment,
+  )
+
+
+def main() -> None:
+  require_tools()
+  usb_storage._validate_nbdkit_installation()
+  with tempfile.TemporaryDirectory(prefix="usb-storage-nbdkit-") as temporary_directory:
+    root = Path(temporary_directory)
+    run_small_image_check(root)
+    run_natural_size_check(root)
+  print("installed nbdkit/FAT integration checks passed")
+
+
+if __name__ == "__main__":
+  main()

--- a/userspace/tests/integration_usb_storage_nbdkit.py
+++ b/userspace/tests/integration_usb_storage_nbdkit.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import os
 from pathlib import Path
@@ -21,7 +22,7 @@ usb_storage = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = usb_storage
 SPEC.loader.exec_module(usb_storage)
 
-REQUIRED_TOOLS = ("nbdkit", "nbdcopy", "nbdinfo", "fsck.fat", "mdir", "mcopy", "dd")
+REQUIRED_TOOLS = ("nbdkit", "nbdcopy", "fsck.fat", "mdir", "mcopy", "dd")
 
 
 def require_tools() -> None:
@@ -30,7 +31,13 @@ def require_tools() -> None:
     raise RuntimeError(f"missing integration-test tools: {', '.join(missing)}")
 
 
-def build_snapshot(root: Path, *, segment_name: str, payload_size: int) -> tuple[Path, str, bytes | None]:
+def build_snapshot(
+  root: Path,
+  *,
+  segment_name: str,
+  payload_size: int,
+  extra_files: dict[str, bytes] | None = None,
+) -> tuple[Path, str, bytes | None]:
   source = root / "realdata"
   source.mkdir(parents=True)
   segment = source / segment_name
@@ -43,6 +50,8 @@ def build_snapshot(root: Path, *, segment_name: str, payload_size: int) -> tuple
   else:
     with payload.open("wb") as stream:
       stream.truncate(payload_size)
+  for name, contents in (extra_files or {}).items():
+    (segment / name).write_bytes(contents)
 
   snapshot = root / usb_storage.MANAGED_SNAPSHOT_NAME
   result = usb_storage.SnapshotBuilder(
@@ -53,6 +62,78 @@ def build_snapshot(root: Path, *, segment_name: str, payload_size: int) -> tuple
   if len(result.included) != 1 or result.excluded:
     raise RuntimeError(f"unexpected snapshot result: {result}")
   return snapshot, result.included[0], expected
+
+
+def materialize_and_check(
+  root: Path,
+  snapshot: Path,
+  *,
+  extracted_path: str,
+  expected_contents: bytes,
+  require_multicluster_root: bool = False,
+) -> None:
+  with tempfile.TemporaryDirectory(prefix="materialized-", dir=root) as temporary_directory:
+    materialized_root = Path(temporary_directory)
+    disk = materialized_root / "disk.img"
+    expected_size, size_argument = usb_storage._nbdkit_layout(snapshot)
+    environment = os.environ.copy()
+    environment.update({"TMPDIR": str(materialized_root), "OUTPUT_IMAGE": str(disk)})
+    command = [
+      "/usr/bin/nbdkit",
+      "--filter=cow",
+      "floppy",
+      f"dir={snapshot}",
+      "label=COMMA",
+    ]
+    if size_argument is not None:
+      command.append(f"size={size_argument}")
+    command.extend([
+      "--run",
+      'exec /usr/bin/nbdcopy --sparse=4096 "$uri" "$OUTPUT_IMAGE"',
+    ])
+    subprocess.run(
+      command,
+      check=True,
+      env=environment,
+    )
+    if disk.stat().st_size != expected_size:
+      raise RuntimeError("nbdkit image size differs from the production layout")
+
+    usb_storage._repair_fat32_image(disk)
+    partition = materialized_root / "partition.img"
+    subprocess.run(
+      ["dd", f"if={disk}", f"of={partition}", "bs=1M", "skip=1", "conv=sparse", "status=none"],
+      check=True,
+    )
+    subprocess.run(["fsck.fat", "-n", "-v", str(partition)], check=True)
+
+    offset_image = f"{disk}@@1048576"
+    listing = subprocess.run(["mdir", "-i", offset_image, "::"], check=True, capture_output=True, text=True)
+    exported_segment = extracted_path.split("/", maxsplit=1)[0]
+    if exported_segment not in listing.stdout:
+      raise RuntimeError("mtools did not preserve the requested exported segment")
+    extracted = materialized_root / "extracted.bin"
+    subprocess.run(
+      ["mcopy", "-i", offset_image, f"::/{extracted_path}", str(extracted)],
+      check=True,
+    )
+    expected_digest = hashlib.sha256(expected_contents).digest()
+    if hashlib.sha256(extracted.read_bytes()).digest() != expected_digest:
+      raise RuntimeError("mtools extraction did not preserve the fixture hash")
+
+    if require_multicluster_root:
+      with disk.open("rb") as image:
+        image.seek(446 + 8)
+        partition_lba = int.from_bytes(image.read(4), "little")
+        image.seek(partition_lba * usb_storage.SECTOR_SIZE + 14)
+        reserved_sectors = int.from_bytes(image.read(2), "little")
+        image.seek(partition_lba * usb_storage.SECTOR_SIZE + 44)
+        root_cluster = int.from_bytes(image.read(4), "little")
+        fat_offset = (partition_lba + reserved_sectors) * usb_storage.SECTOR_SIZE
+        image.seek(fat_offset + root_cluster * 4)
+        next_root_cluster = int.from_bytes(image.read(4), "little") & 0x0FFFFFFF
+      if not 2 <= next_root_cluster < usb_storage.FAT32_END_OF_CHAIN:
+        raise RuntimeError("installed nbdkit image did not create a multi-cluster FAT root directory")
 
 
 def run_small_image_check(root: Path) -> None:
@@ -66,77 +147,83 @@ def run_small_image_check(root: Path) -> None:
   if expected is None:
     raise RuntimeError("small fixture was not materialized")
 
-  disk = small_root / "disk.img"
-  environment = os.environ.copy()
-  environment.update({"TMPDIR": str(small_root), "OUTPUT_IMAGE": str(disk)})
-  subprocess.run(
-    [
-      "/usr/bin/nbdkit",
-      "--filter=cow",
-      "floppy",
-      f"dir={snapshot}",
-      "label=COMMA",
-      f"size={usb_storage.MIN_COMPATIBLE_DISK_SIZE}",
-      "--run",
-      'exec /usr/bin/nbdcopy --sparse=1048576 "$uri" "$OUTPUT_IMAGE"',
-    ],
-    check=True,
-    env=environment,
+  materialize_and_check(
+    small_root,
+    snapshot,
+    extracted_path=f"{exported_segment}/fcamera.hevc",
+    expected_contents=expected,
   )
-  expected_size, _size_argument = usb_storage._nbdkit_layout(snapshot)
-  if disk.stat().st_size != expected_size:
-    raise RuntimeError("nbdkit image size differs from the production layout")
-
-  usb_storage._repair_fat32_image(disk)
-  partition = small_root / "partition.img"
-  subprocess.run(
-    ["dd", f"if={disk}", f"of={partition}", "bs=1M", "skip=1", "conv=sparse", "status=none"],
-    check=True,
-  )
-  subprocess.run(["fsck.fat", "-n", "-v", str(partition)], check=True)
-
-  offset_image = f"{disk}@@1048576"
-  listing = subprocess.run(["mdir", "-i", offset_image, "::"], check=True, capture_output=True, text=True)
-  if exported_segment not in listing.stdout:
-    raise RuntimeError("mtools did not preserve the exported segment name")
-  extracted = small_root / "extracted.hevc"
-  subprocess.run(
-    ["mcopy", "-i", offset_image, f"::/{exported_segment}/fcamera.hevc", str(extracted)],
-    check=True,
-  )
-  if extracted.read_bytes() != expected:
-    raise RuntimeError("mtools extraction did not preserve fixture bytes")
 
 
 def run_natural_size_check(root: Path) -> None:
   large_root = root / "natural"
   large_root.mkdir()
-  # Root directory + segment directory consume two clusters. The sparse file
-  # fills the rest of the conservative FAT32 boundary exactly.
-  payload_size = (usb_storage.FAT32_COMPATIBLE_DATA_CLUSTERS - 2) * usb_storage.FAT_CLUSTER_SIZE
-  snapshot, _exported_segment, _expected = build_snapshot(
+  proof_name = "proof.bin"
+  proof_contents = b"natural-size nbdkit repair and extraction proof\x00\xff"
+  # Root directory, segment directory, and proof file consume three clusters.
+  # The sparse camera file fills the rest of the conservative boundary exactly.
+  payload_size = (usb_storage.FAT32_COMPATIBLE_DATA_CLUSTERS - 3) * usb_storage.FAT_CLUSTER_SIZE
+  snapshot, exported_segment, _expected = build_snapshot(
     large_root,
     segment_name="00000001--abc123def0--0",
     payload_size=payload_size,
+    extra_files={proof_name: proof_contents},
   )
   expected_size, size_argument = usb_storage._nbdkit_layout(snapshot)
   if size_argument is not None or expected_size != usb_storage.MIN_COMPATIBLE_DISK_SIZE:
     raise RuntimeError("natural-size fixture did not hit the exact unpadded boundary")
+  sparse_payload = large_root / "realdata" / exported_segment / "fcamera.hevc"
+  sparse_metadata = sparse_payload.stat()
+  if sparse_metadata.st_size != payload_size or sparse_metadata.st_blocks != 0:
+    raise RuntimeError("natural-size fixture payload was not created as a hole-only sparse file")
 
-  environment = os.environ.copy()
-  environment.update({"TMPDIR": str(large_root), "EXPECTED_SIZE": str(expected_size)})
-  subprocess.run(
-    [
-      "/usr/bin/nbdkit",
-      "--filter=cow",
-      "floppy",
-      f"dir={snapshot}",
-      "label=COMMA",
-      "--run",
-      'test "$(/usr/bin/nbdinfo --size "$uri")" = "$EXPECTED_SIZE"',
-    ],
-    check=True,
-    env=environment,
+  materialize_and_check(
+    large_root,
+    snapshot,
+    extracted_path=f"{exported_segment}/{proof_name}",
+    expected_contents=proof_contents,
+  )
+
+
+def run_multicluster_root_check(root: Path) -> None:
+  multicluster_root = root / "multicluster-root"
+  source = multicluster_root / "realdata"
+  source.mkdir(parents=True)
+  segment_count = 172
+  marker_name = "marker.bin"
+  late_marker = b"late FAT root-chain entry\x00\xff"
+  late_segment = ""
+  root_entries = 1  # volume label
+
+  for index in range(segment_count):
+    segment_name = f"{index:08x}--abc123def0--0"
+    segment = source / segment_name
+    segment.mkdir()
+    contents = late_marker if index == segment_count - 1 else f"segment {index}\n".encode()
+    (segment / marker_name).write_bytes(contents)
+    root_entries += 1 + usb_storage._lfn_entry_count(segment_name)
+    late_segment = segment_name
+
+  if root_entries * 32 <= usb_storage.FAT_CLUSTER_SIZE:
+    raise RuntimeError("multi-cluster fixture did not exceed one FAT root-directory cluster")
+
+  snapshot = multicluster_root / usb_storage.MANAGED_SNAPSHOT_NAME
+  result = usb_storage.SnapshotBuilder(
+    source,
+    snapshot,
+    wall_clock_ns=lambda: time.time_ns() + 10 * usb_storage.DEFAULT_STABILITY_AGE_NS,
+  ).build()
+  if len(result.included) != segment_count or result.excluded:
+    raise RuntimeError(f"unexpected multi-cluster snapshot result: {result}")
+  if result.included[-1] != late_segment:
+    raise RuntimeError("multi-cluster fixture did not preserve the expected late segment name")
+
+  materialize_and_check(
+    multicluster_root,
+    snapshot,
+    extracted_path=f"{late_segment}/{marker_name}",
+    expected_contents=late_marker,
+    require_multicluster_root=True,
   )
 
 
@@ -147,6 +234,7 @@ def main() -> None:
     root = Path(temporary_directory)
     run_small_image_check(root)
     run_natural_size_check(root)
+    run_multicluster_root_check(root)
   print("installed nbdkit/FAT integration checks passed")
 
 

--- a/userspace/tests/test_cleanup_usb_storage.py
+++ b/userspace/tests/test_cleanup_usb_storage.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import errno
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import types
+import unittest  # noqa: TID251 - these tests intentionally use only the standard library
+from unittest import mock  # noqa: TID251 - these tests intentionally use only the standard library
+
+
+USERSPACE = Path(__file__).parents[1]
+COMMA_DIR = USERSPACE / "root" / "usr" / "comma"
+POST_STOP = COMMA_DIR / "cleanup_usb_storage.sh"
+STORAGE_SERVICE = USERSPACE / "root" / "usr" / "lib" / "systemd" / "system" / "usb-storage.service"
+sys.path.insert(0, str(COMMA_DIR))
+
+import cleanup_usb_storage  # noqa: E402, RUF100
+import usb_storage  # noqa: E402, RUF100
+
+
+class StoppedStorageCleanupTest(unittest.TestCase):
+  def setUp(self) -> None:
+    self.temporary_directory = tempfile.TemporaryDirectory()
+    self.root = Path(self.temporary_directory.name)
+    self.source = self.root / "realdata"
+    self.source.mkdir()
+    self.snapshot = self.root / usb_storage.MANAGED_SNAPSHOT_NAME
+    self.mount_parent = self.root / usb_storage.MANAGED_MOUNT_DIRECTORY
+    self.mount_parent.mkdir()
+    self.mount = self.mount_parent / usb_storage.MANAGED_MOUNT_NAME
+    self.pidfile = self.mount_parent.with_suffix(".pid")
+
+  def tearDown(self) -> None:
+    if self.snapshot.exists() and not self.snapshot.is_symlink():
+      usb_storage.SnapshotBuilder(self.source, self.snapshot).cleanup()
+    self.temporary_directory.cleanup()
+
+  def cleaner(self, **kwargs: object) -> cleanup_usb_storage.StoppedStorageCleanup:
+    return cleanup_usb_storage.StoppedStorageCleanup(
+      source=self.source,
+      snapshot=self.snapshot,
+      mount=self.mount,
+      **kwargs,
+    )
+
+  def test_clean_stop_is_an_idempotent_noop(self) -> None:
+    def unexpected_runner(*_args: object, **_kwargs: object) -> None:
+      self.fail("fusermount3 must not run for a clean stop")
+
+    self.cleaner(command_runner=unexpected_runner, mount_inspector=lambda _path: ()).cleanup()
+
+    self.assertFalse(self.snapshot.exists())
+    self.assertFalse(self.mount.exists())
+    self.assertFalse(self.pidfile.exists())
+
+  def test_forced_stop_detaches_then_removes_only_managed_artifacts(self) -> None:
+    source_file = self.source / "route.log"
+    source_file.write_bytes(b"pinned footage")
+    self.snapshot.mkdir()
+    snapshot_file = self.snapshot / "route.log"
+    os.link(source_file, snapshot_file)
+    self.mount.write_bytes(b"stale virtual file")
+    self.pidfile.write_text("123\n")
+    active = True
+    commands: list[list[str]] = []
+
+    def mount_inspector(_path: Path) -> tuple[tuple[str, str], ...]:
+      return (("fuse.nbdfuse", "nbdfuse"),) if active else ()
+
+    def runner(command: list[str], **_kwargs: object) -> types.SimpleNamespace:
+      nonlocal active
+      commands.append(command)
+      active = False
+      return types.SimpleNamespace(returncode=0)
+
+    cleaner = self.cleaner(command_runner=runner, mount_inspector=mount_inspector)
+    cleaner.cleanup()
+
+    self.assertEqual(commands, [["/usr/bin/fusermount3", "-uz", str(cleaner.mount_parent)]])
+    self.assertFalse(self.snapshot.exists())
+    self.assertFalse(self.mount.exists())
+    self.assertFalse(self.pidfile.exists())
+    self.assertEqual(source_file.read_bytes(), b"pinned footage")
+
+  def test_unsafe_snapshot_is_preserved_before_any_detach_or_unlink(self) -> None:
+    foreign = self.root / "foreign"
+    foreign.mkdir()
+    foreign_file = foreign / "private"
+    foreign_file.write_text("preserve")
+    self.snapshot.symlink_to(foreign, target_is_directory=True)
+    self.mount.write_bytes(b"preserve")
+    self.pidfile.write_text("123\n")
+
+    with self.assertRaises(usb_storage.StorageError):
+      self.cleaner(mount_inspector=lambda _path: ()).cleanup()
+
+    self.assertTrue(self.snapshot.is_symlink())
+    self.assertTrue(self.mount.exists())
+    self.assertTrue(self.pidfile.exists())
+    self.assertEqual(foreign_file.read_text(), "preserve")
+
+  def test_failed_stale_unmount_preserves_backing_state(self) -> None:
+    self.snapshot.mkdir()
+    (self.snapshot / "route.log").write_bytes(b"pinned")
+    self.mount.write_bytes(b"stale virtual file")
+    self.pidfile.write_text("123\n")
+
+    with self.assertRaisesRegex(usb_storage.StorageError, "status 7"):
+      self.cleaner(
+        command_runner=lambda *_args, **_kwargs: types.SimpleNamespace(returncode=7),
+        mount_inspector=lambda _path: (("fuse.nbdfuse", "nbdfuse"),),
+      ).cleanup()
+
+    self.assertTrue(self.snapshot.exists())
+    self.assertTrue(self.mount.exists())
+    self.assertTrue(self.pidfile.exists())
+
+  def test_dead_fuse_is_detached_before_mountpoint_path_inspection(self) -> None:
+    self.snapshot.mkdir()
+    (self.snapshot / "route.log").write_bytes(b"pinned")
+    self.mount.write_bytes(b"stale virtual file")
+    self.pidfile.write_text("123\n")
+    active = True
+
+    def mount_inspector(_path: Path) -> tuple[tuple[str, str], ...]:
+      return (("fuse.nbdfuse", "nbdfuse"),) if active else ()
+
+    def runner(*_args: object, **_kwargs: object) -> types.SimpleNamespace:
+      nonlocal active
+      active = False
+      return types.SimpleNamespace(returncode=0)
+
+    cleaner = self.cleaner(command_runner=runner, mount_inspector=mount_inspector)
+    real_resolve = Path.resolve
+    real_lstat = Path.lstat
+
+    def guarded_resolve(path: Path, strict: bool = False) -> Path:
+      if path == self.mount_parent and active:
+        raise OSError(errno.ENOTCONN, "dead FUSE")
+      return real_resolve(path, strict=strict)
+
+    def guarded_lstat(path: Path) -> os.stat_result:
+      if path == self.mount_parent and active:
+        raise OSError(errno.ENOTCONN, "dead FUSE")
+      return real_lstat(path)
+
+    with mock.patch.object(Path, "resolve", guarded_resolve), mock.patch.object(Path, "lstat", guarded_lstat):
+      cleaner.cleanup()
+
+    self.assertFalse(self.snapshot.exists())
+    self.assertFalse(self.mount.exists())
+    self.assertFalse(self.pidfile.exists())
+
+  def test_foreign_mount_is_never_detached_or_cleaned(self) -> None:
+    self.snapshot.mkdir()
+    (self.snapshot / "route.log").write_bytes(b"pinned")
+    self.pidfile.write_text("123\n")
+
+    def unexpected_runner(*_args: object, **_kwargs: object) -> None:
+      self.fail("foreign mount must not be detached")
+
+    with self.assertRaisesRegex(usb_storage.StorageError, "foreign filesystem"):
+      self.cleaner(
+        command_runner=unexpected_runner,
+        mount_inspector=lambda _path: (("ext4", "/dev/private"),),
+      ).cleanup()
+
+    self.assertTrue(self.snapshot.exists())
+    self.assertTrue(self.pidfile.exists())
+
+  def test_foreign_fuse_cannot_spoof_nbdfuse_with_its_source_basename(self) -> None:
+    self.snapshot.mkdir()
+    (self.snapshot / "route.log").write_bytes(b"pinned")
+
+    def unexpected_runner(*_args: object, **_kwargs: object) -> None:
+      self.fail("spoofed foreign FUSE mount must not be detached")
+
+    with self.assertRaisesRegex(usb_storage.StorageError, "foreign filesystem"):
+      self.cleaner(
+        command_runner=unexpected_runner,
+        mount_inspector=lambda _path: (("fuse.sshfs", "/foreign/nbdfuse"),),
+      ).cleanup()
+
+    self.assertTrue(self.snapshot.exists())
+
+  def test_mount_inspection_error_is_not_treated_as_no_mount(self) -> None:
+    self.snapshot.mkdir()
+    (self.snapshot / "route.log").write_bytes(b"pinned")
+
+    def unavailable(_path: Path) -> tuple[tuple[str, str], ...]:
+      raise OSError(errno.EIO, "mount table unavailable")
+
+    with self.assertRaisesRegex(usb_storage.StorageError, "cannot inspect"):
+      self.cleaner(mount_inspector=unavailable).cleanup()
+
+    self.assertTrue(self.snapshot.exists())
+
+  def test_mountinfo_parser_matches_only_the_exact_managed_target(self) -> None:
+    mountinfo = self.root / "mountinfo"
+    mountinfo.write_text(
+      "".join((
+        "35 24 0:31 / /run rw - tmpfs tmpfs rw\n",
+        "36 35 0:32 / /run/usb-storage rw - fuse.nbdfuse nbdfuse rw\n",
+        "37 35 0:33 / /run/usb-storage-extra rw - ext4 /dev/private rw\n",
+      )),
+    )
+
+    entries = cleanup_usb_storage._mountinfo_entries(Path("/run/usb-storage"), mountinfo=mountinfo)
+
+    self.assertEqual(entries, (("fuse.nbdfuse", "nbdfuse"),))
+
+
+class PostStopWrapperTest(unittest.TestCase):
+  def setUp(self) -> None:
+    self.temporary_directory = tempfile.TemporaryDirectory()
+    self.root = Path(self.temporary_directory.name)
+    self.log = self.root / "order.log"
+    self.helper = self.root / "helper"
+    self.helper.write_text(
+      "".join((
+        "#!/bin/sh\n",
+        "printf 'helper:%s\\n' \"$1\" >> \"$POST_STOP_LOG\"\n",
+      )),
+    )
+    self.helper.chmod(0o755)
+    self.cleanup = self.root / "cleanup"
+    self.cleanup.write_text(
+      "".join((
+        "#!/bin/sh\n",
+        "printf 'cleanup\\n' >> \"$POST_STOP_LOG\"\n",
+      )),
+    )
+    self.cleanup.chmod(0o755)
+    self.environment = os.environ.copy()
+    self.environment.update({
+      "POST_STOP_LOG": str(self.log),
+      "USB_GADGET_HELPER": str(self.helper),
+      "USB_STORAGE_CLEANUP_BIN": str(self.cleanup),
+    })
+
+  def tearDown(self) -> None:
+    self.temporary_directory.cleanup()
+
+  def test_cleanup_finishes_before_safe_personality_reconstruction(self) -> None:
+    subprocess.run([str(POST_STOP)], env=self.environment, check=True, capture_output=True, text=True)
+
+    self.assertEqual(self.log.read_text().splitlines(), [
+      "helper:prepare-storage-post-stop",
+      "cleanup",
+      "helper:ensure-requested-personality",
+    ])
+
+  def test_cleanup_failure_forces_unbind_and_never_reconstructs(self) -> None:
+    self.cleanup.write_text("#!/bin/sh\nexit 9\n")
+
+    result = subprocess.run([str(POST_STOP)], env=self.environment, check=False, capture_output=True, text=True)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertEqual(self.log.read_text().splitlines(), [
+      "helper:prepare-storage-post-stop",
+      "helper:unbind",
+    ])
+
+  def test_reconstruction_failure_happens_only_after_cleanup_and_stays_unbound(self) -> None:
+    self.helper.write_text(
+      "".join((
+        "#!/bin/sh\n",
+        "printf 'helper:%s\\n' \"$1\" >> \"$POST_STOP_LOG\"\n",
+        "[ \"$1\" != ensure-requested-personality ]\n",
+      )),
+    )
+
+    result = subprocess.run([str(POST_STOP)], env=self.environment, check=False, capture_output=True, text=True)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertEqual(self.log.read_text().splitlines(), [
+      "helper:prepare-storage-post-stop",
+      "cleanup",
+      "helper:ensure-requested-personality",
+      "helper:unbind",
+    ])
+
+  def test_service_runs_post_stop_cleanup_after_control_group_shutdown(self) -> None:
+    unit = STORAGE_SERVICE.read_text()
+
+    self.assertIn("ExecStopPost=/usr/comma/cleanup_usb_storage.sh\n", unit)
+    self.assertIn("KillMode=control-group\n", unit)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/userspace/tests/test_usb_gadget.py
+++ b/userspace/tests/test_usb_gadget.py
@@ -333,6 +333,63 @@ class UsbGadgetTest(unittest.TestCase):
     self.assertEqual(self.read(self.gadget / "idProduct"), "0xBEEF")
     self.assert_storage_only_links()
 
+  def test_requested_personality_recovery_serializes_partial_failed_state(self) -> None:
+    self.run_helper("configure", "1")
+    failing_link = self.root / "failing-concurrent-link"
+    failing_link.write_text("#!/bin/sh\nexit 1\n")
+    failing_link.chmod(0o755)
+    self.environment["USB_GADGET_LN_BIN"] = str(failing_link)
+
+    result = self.run_helper("configure", "0", check=False)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertFalse((self.config / "mass_storage.0").is_symlink())
+
+    # Use a portable flock shim so this concurrency check also runs on macOS.
+    # flock(2) is attached to the inherited open file description, so the
+    # parent shell keeps the lock after this helper exits and until it closes
+    # descriptor 9.
+    flock_wrapper = self.root / "flock"
+    flock_wrapper.write_text(
+      "#!/usr/bin/env python3\n"
+      "import fcntl\n"
+      "import sys\n"
+      "fcntl.flock(int(sys.argv[-1]), fcntl.LOCK_EX)\n",
+    )
+    flock_wrapper.chmod(0o755)
+    slow_link = self.root / "slow-logged-ln"
+    slow_link.write_text(
+      "#!/bin/sh\n"
+      "sleep 0.1\n"
+      "printf '%s\\n' \"${3##*/}\" >> \"$USB_GADGET_LINK_LOG\"\n"
+      "exec /bin/ln \"$@\"\n",
+    )
+    slow_link.chmod(0o755)
+    self.environment["USB_GADGET_FLOCK_BIN"] = str(flock_wrapper)
+    self.environment["USB_GADGET_LN_BIN"] = str(slow_link)
+    self.adb_param.write_text("1\n")
+    self.link_log.write_text("")
+
+    processes = [
+      subprocess.Popen(
+        [str(GADGET_HELPER), "ensure-requested-personality"],
+        env=self.environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+      )
+      for _ in range(2)
+    ]
+    results = [process.communicate(timeout=10) for process in processes]
+
+    self.assertEqual([process.returncode for process in processes], [0, 0], results)
+    self.assertEqual(self.read(self.gadget / "UDC"), "a600000.dwc3")
+    self.assertEqual(self.read(self.gadget / "idVendor"), "0x04D8")
+    self.assertEqual(self.read(self.gadget / "idProduct"), "0x1234")
+    self.assertEqual(self.link_log.read_text().splitlines(), ["ncm.0", "ffs.adb", "mass_storage.0"])
+    self.assert_debug_links()
+
   def test_symbolic_link_lock_is_rejected_without_touching_target(self) -> None:
     lock = Path(self.environment["USB_GADGET_LOCK_FILE"])
     victim = self.root / "victim"
@@ -370,6 +427,14 @@ class UsbGadgetTest(unittest.TestCase):
       unit.index("ExecStartPre=/usr/comma/usb_gadget.sh prepare-storage-start"),
       unit.index("ExecStartPre=-/usr/bin/fusermount3 -uz /run/usb-storage"),
     )
+
+  def test_storage_service_backs_off_repeated_start_failures(self) -> None:
+    unit = STORAGE_SERVICE.read_text()
+
+    self.assertIn("Restart=on-failure\n", unit)
+    self.assertIn("RestartSec=5\n", unit)
+    self.assertIn("RestartSteps=5\n", unit)
+    self.assertIn("RestartMaxDelaySec=5min\n", unit)
 
   def test_stop_wrapper_signals_manager_before_final_unbind(self) -> None:
     event_log = self.root / "stop-order.log"

--- a/userspace/tests/test_usb_gadget.py
+++ b/userspace/tests/test_usb_gadget.py
@@ -305,6 +305,24 @@ class UsbGadgetTest(unittest.TestCase):
           unexpected.rmdir()
         self.run_helper("configure", "1")
 
+  def test_reenumeration_rejects_hidden_foreign_function_without_modifying_it(self) -> None:
+    self.adb_param.write_text("1\n")
+    self.run_helper("configure", "1")
+    (self.lun / "file").write_text("/run/usb-storage/footage.img\n")
+    foreign_function = self.gadget / "functions" / "ecm.0"
+    foreign_function.mkdir()
+    hidden_link = self.config / ".foreign-function"
+    hidden_link.symlink_to(foreign_function)
+
+    result = self.run_helper("reenumerate-managed-storage", check=False)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertIn("unexpected USB function", result.stderr)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertEqual(self.read(self.lun / "file"), "/run/usb-storage/footage.img")
+    self.assertTrue(hidden_link.is_symlink())
+    self.assertEqual(os.readlink(hidden_link), str(foreign_function))
+
   def test_reenumeration_sleep_failure_stays_unbound_with_media_intact(self) -> None:
     self.adb_param.write_text("1\n")
     self.run_helper("configure", "1")
@@ -467,6 +485,138 @@ class UsbGadgetTest(unittest.TestCase):
     self.assertIn("media remains attached", result.stderr)
     self.assertEqual(self.read(self.gadget / "UDC"), "")
     self.assertEqual(self.read(self.lun / "file"), "/run/usb-storage/footage.img")
+    self.assert_debug_links()
+
+  def test_post_stop_cleanup_is_noop_for_clean_managed_personality(self) -> None:
+    self.adb_param.write_text("1\n")
+    self.run_helper("configure", "1")
+
+    self.run_helper("prepare-storage-post-stop")
+
+    self.assertEqual(self.read(self.gadget / "UDC"), "a600000.dwc3")
+    self.assertEqual(self.read(self.lun / "file"), "")
+    self.assert_debug_links()
+
+  def test_post_stop_cleanup_clears_managed_media_and_stays_unbound(self) -> None:
+    self.adb_param.write_text("1\n")
+    self.run_helper("configure", "1")
+    (self.lun / "file").write_text("/run/usb-storage/footage.img\n")
+
+    self.run_helper("prepare-storage-post-stop")
+
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertEqual(self.read(self.lun / "file"), "")
+    self.assert_debug_links()
+
+  def test_post_stop_cleanup_preserves_foreign_media_and_fails_unbound(self) -> None:
+    self.adb_param.write_text("1\n")
+    self.run_helper("configure", "1")
+    (self.lun / "file").write_text("/data/private.img\n")
+
+    result = self.run_helper("prepare-storage-post-stop", check=False)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertIn("foreign", result.stderr)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertEqual(self.read(self.lun / "file"), "/data/private.img")
+    self.assert_debug_links()
+
+  def test_post_stop_cleanup_releases_media_before_rejecting_foreign_links(self) -> None:
+    self.adb_param.write_text("1\n")
+    self.run_helper("configure", "1")
+    (self.lun / "file").write_text("/run/usb-storage/footage.img\n")
+    foreign_function = self.gadget / "functions" / "ecm.0"
+    foreign_function.mkdir()
+    hidden_link = self.config / ".foreign-function"
+    hidden_link.symlink_to(foreign_function)
+
+    self.run_helper("prepare-storage-post-stop")
+
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertEqual(self.read(self.lun / "file"), "")
+    self.assertTrue(hidden_link.is_symlink())
+
+    result = self.run_helper("ensure-requested-personality", check=False)
+    self.assertNotEqual(result.returncode, 0)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertTrue(hidden_link.is_symlink())
+
+  def test_post_stop_cleanup_preserves_unsafe_managed_lun_policy(self) -> None:
+    self.adb_param.write_text("1\n")
+    self.run_helper("configure", "1")
+    (self.lun / "file").write_text("/run/usb-storage/footage.img\n")
+    (self.lun / "ro").write_text("0\n")
+
+    result = self.run_helper("prepare-storage-post-stop", check=False)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertIn("policy is unsafe", result.stderr)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertEqual(self.read(self.lun / "file"), "/run/usb-storage/footage.img")
+    self.assertEqual(self.read(self.lun / "ro"), "0")
+
+  def test_post_stop_cleanup_never_follows_lun_attribute_symlink(self) -> None:
+    self.adb_param.write_text("1\n")
+    self.run_helper("configure", "1")
+    foreign_attribute = self.root / "foreign-lun-file"
+    foreign_attribute.write_text("/run/usb-storage/footage.img\n")
+    (self.lun / "file").unlink()
+    (self.lun / "file").symlink_to(foreign_attribute)
+
+    result = self.run_helper("prepare-storage-post-stop", check=False)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertIn("unavailable or unsafe", result.stderr)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertTrue((self.lun / "file").is_symlink())
+    self.assertEqual(foreign_attribute.read_text(), "/run/usb-storage/footage.img\n")
+
+  def test_post_stop_cleanup_is_not_blocked_by_adb_off_identity_approval(self) -> None:
+    self.adb_param.write_text("1\n")
+    self.run_helper("configure", "1")
+    (self.lun / "file").write_text("/run/usb-storage/footage.img\n")
+    self.adb_param.write_text("0\n")
+    del self.environment["USB_GADGET_STORAGE_ONLY_VID"]
+    del self.environment["USB_GADGET_STORAGE_ONLY_PID"]
+
+    self.run_helper("prepare-storage-post-stop")
+
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertEqual(self.read(self.lun / "file"), "")
+    result = self.run_helper("ensure-requested-personality", check=False)
+    self.assertNotEqual(result.returncode, 0)
+    self.assertIn("owner-approved", result.stderr)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+
+  def test_post_stop_cleanup_releases_media_despite_partial_descriptors(self) -> None:
+    self.adb_param.write_text("1\n")
+    self.run_helper("configure", "1")
+    (self.lun / "file").write_text("/run/usb-storage/footage.img\n")
+    (self.gadget / "idProduct").write_text("0xffff\n")
+    (self.config / "ffs.adb").unlink()
+
+    self.run_helper("prepare-storage-post-stop")
+
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertEqual(self.read(self.lun / "file"), "")
+    self.run_helper("ensure-requested-personality")
+    self.assertEqual(self.read(self.gadget / "UDC"), "a600000.dwc3")
+    self.assertEqual(self.read(self.gadget / "idProduct"), "0x1234")
+    self.assert_debug_links()
+
+  def test_post_stop_cleanup_unbinds_empty_partial_personality_before_repair(self) -> None:
+    self.adb_param.write_text("1\n")
+    self.run_helper("configure", "1")
+    (self.gadget / "idProduct").write_text("0xffff\n")
+    (self.config / "ffs.adb").unlink()
+
+    self.run_helper("prepare-storage-post-stop")
+
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertEqual(self.read(self.lun / "file"), "")
+    self.run_helper("ensure-requested-personality")
+    self.assertEqual(self.read(self.gadget / "UDC"), "a600000.dwc3")
+    self.assertEqual(self.read(self.gadget / "idProduct"), "0x1234")
     self.assert_debug_links()
 
   def test_storage_start_clears_only_managed_media_before_rebinding(self) -> None:

--- a/userspace/tests/test_usb_gadget.py
+++ b/userspace/tests/test_usb_gadget.py
@@ -207,6 +207,224 @@ class UsbGadgetTest(unittest.TestCase):
     self.assertEqual(self.read(self.gadget / "UDC"), "a600000.dwc3")
     self.assert_storage_only_links()
 
+  def test_managed_storage_reenumeration_preserves_complete_debug_personality(self) -> None:
+    self.adb_param.write_text("1\n")
+    self.run_helper("configure", "1")
+    # Real configfs normalizes hexadecimal USB IDs to lowercase on readback.
+    (self.gadget / "idVendor").write_text("0x04d8\n")
+    (self.lun / "file").write_text("/run/usb-storage/footage.img\n")
+    sleep_log = self.root / "reenumerate-sleep.log"
+    sleep_wrapper = self.root / "logged-sleep"
+    sleep_wrapper.write_text(
+      "#!/bin/sh\n"
+      "printf '%s\\n' \"$1\" >> \"$USB_GADGET_SLEEP_LOG\"\n",
+    )
+    sleep_wrapper.chmod(0o755)
+    self.environment["USB_GADGET_SLEEP_BIN"] = str(sleep_wrapper)
+    self.environment["USB_GADGET_SLEEP_LOG"] = str(sleep_log)
+    descriptors_before = {
+      path: self.read(path)
+      for path in (
+        self.gadget / "idVendor",
+        self.gadget / "idProduct",
+        self.gadget / "strings" / "0x409" / "serialnumber",
+        self.config / "strings" / "0x409" / "configuration",
+        self.lun / "file",
+        self.lun / "ro",
+        self.lun / "removable",
+        self.mass_storage / "stall",
+      )
+    }
+    links_before = {path.name: os.readlink(path) for path in self.config.iterdir() if path.is_symlink()}
+    link_log_before = self.link_log.read_text()
+
+    self.run_helper("reenumerate-managed-storage")
+
+    self.assertEqual(self.read(self.gadget / "UDC"), "a600000.dwc3")
+    self.assertEqual({path: self.read(path) for path in descriptors_before}, descriptors_before)
+    self.assertEqual({path.name: os.readlink(path) for path in self.config.iterdir() if path.is_symlink()}, links_before)
+    self.assertEqual(self.link_log.read_text(), link_log_before)
+    self.assertEqual(sleep_log.read_text().splitlines(), ["1"])
+    self.assert_debug_links()
+
+  def test_managed_storage_reenumeration_preserves_storage_only_personality(self) -> None:
+    self.adb_param.write_text("0\n")
+    self.run_helper("configure", "0")
+    (self.gadget / "idVendor").write_text("0xcafe\n")
+    (self.gadget / "idProduct").write_text("0xbeef\n")
+    (self.lun / "file").write_text("/run/usb-storage/footage.img\n")
+
+    self.run_helper("reenumerate-managed-storage")
+
+    self.assertEqual(self.read(self.gadget / "UDC"), "a600000.dwc3")
+    self.assertEqual(self.read(self.gadget / "idVendor"), "0xcafe")
+    self.assertEqual(self.read(self.gadget / "idProduct"), "0xbeef")
+    self.assertEqual(self.read(self.lun / "file"), "/run/usb-storage/footage.img")
+    self.assert_storage_only_links()
+
+  def test_reenumeration_rejects_unsafe_lun_and_leaves_gadget_unbound(self) -> None:
+    self.adb_param.write_text("1\n")
+    self.run_helper("configure", "1")
+    (self.lun / "file").write_text("/run/usb-storage/footage.img\n")
+    (self.lun / "ro").write_text("0\n")
+
+    result = self.run_helper("reenumerate-managed-storage", check=False)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertIn("unsafe or unmanaged", result.stderr)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertEqual(self.read(self.lun / "file"), "/run/usb-storage/footage.img")
+    self.assertEqual(self.read(self.lun / "ro"), "0")
+
+  def test_reenumeration_never_binds_partial_or_unexpected_functions(self) -> None:
+    for mutation in ("missing-adb", "unexpected-function"):
+      with self.subTest(mutation=mutation):
+        self.adb_param.write_text("1\n")
+        self.run_helper("configure", "1")
+        (self.lun / "file").write_text("/run/usb-storage/footage.img\n")
+        if mutation == "missing-adb":
+          (self.config / "ffs.adb").unlink()
+        else:
+          unexpected = self.gadget / "functions" / "ecm.0"
+          unexpected.mkdir()
+          (self.config / "ecm.0").symlink_to(unexpected)
+
+        result = self.run_helper("reenumerate-managed-storage", check=False)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("re-enumerate", result.stderr)
+        self.assertEqual(self.read(self.gadget / "UDC"), "")
+        self.assertEqual(self.read(self.lun / "file"), "/run/usb-storage/footage.img")
+
+        # Restore a clean fake configfs tree for the next subtest without
+        # teaching the product helper how to repair a partial personality.
+        if mutation == "missing-adb":
+          (self.config / "ffs.adb").symlink_to(self.gadget / "functions" / "ffs.adb")
+        else:
+          (self.config / "ecm.0").unlink()
+          unexpected.rmdir()
+        self.run_helper("configure", "1")
+
+  def test_reenumeration_sleep_failure_stays_unbound_with_media_intact(self) -> None:
+    self.adb_param.write_text("1\n")
+    self.run_helper("configure", "1")
+    (self.lun / "file").write_text("/run/usb-storage/footage.img\n")
+    failing_sleep = self.root / "failing-sleep"
+    failing_sleep.write_text("#!/bin/sh\nexit 1\n")
+    failing_sleep.chmod(0o755)
+    self.environment["USB_GADGET_SLEEP_BIN"] = str(failing_sleep)
+
+    result = self.run_helper("reenumerate-managed-storage", check=False)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertEqual(self.read(self.lun / "file"), "/run/usb-storage/footage.img")
+    self.assert_debug_links()
+
+  def test_configure_rejects_extra_private_lun_without_modifying_it(self) -> None:
+    self.adb_param.write_text("1\n")
+    self.run_helper("configure", "1")
+    extra_lun = self.mass_storage / "lun.1"
+    extra_lun.mkdir()
+    (extra_lun / "file").write_text("/data/private.img\n")
+    (extra_lun / "ro").write_text("0\n")
+    (extra_lun / "removable").write_text("0\n")
+
+    result = self.run_helper("configure", "1", check=False)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertIn("more than LUN 0", result.stderr)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertEqual(self.read(extra_lun / "file"), "/data/private.img")
+    self.assertEqual(self.read(extra_lun / "ro"), "0")
+    self.assertEqual(self.read(extra_lun / "removable"), "0")
+    self.assertFalse((self.config / "mass_storage.0").is_symlink())
+    self.assertFalse((self.config / "ncm.0").is_symlink())
+    self.assertFalse((self.config / "ffs.adb").is_symlink())
+
+  def test_reenumeration_rejects_extra_private_lun_without_modifying_it(self) -> None:
+    self.adb_param.write_text("1\n")
+    self.run_helper("configure", "1")
+    (self.lun / "file").write_text("/run/usb-storage/footage.img\n")
+    extra_lun = self.mass_storage / "lun.1"
+    extra_lun.mkdir()
+    (extra_lun / "file").write_text("/data/private.img\n")
+    (extra_lun / "ro").write_text("0\n")
+    (extra_lun / "removable").write_text("0\n")
+
+    result = self.run_helper("reenumerate-managed-storage", check=False)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertIn("more than LUN 0", result.stderr)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertEqual(self.read(self.lun / "file"), "/run/usb-storage/footage.img")
+    self.assertEqual(self.read(extra_lun / "file"), "/data/private.img")
+    self.assertEqual(self.read(extra_lun / "ro"), "0")
+    self.assert_debug_links()
+
+  def test_configure_rejects_alternate_config_without_modifying_it(self) -> None:
+    self.adb_param.write_text("1\n")
+    self.run_helper("configure", "1")
+    foreign_function = self.gadget / "functions" / "mass_storage.1"
+    foreign_lun = foreign_function / "lun.0"
+    foreign_lun.mkdir(parents=True)
+    (foreign_lun / "file").write_text("/data/private.img\n")
+    (foreign_lun / "ro").write_text("0\n")
+    alternate_config = self.gadget / "configs" / "c.2"
+    alternate_config.mkdir()
+    (alternate_config / "mass_storage.1").symlink_to(foreign_function)
+
+    result = self.run_helper("configure", "1", check=False)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertIn("more than configuration c.1", result.stderr)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertEqual(self.read(foreign_lun / "file"), "/data/private.img")
+    self.assertEqual(self.read(foreign_lun / "ro"), "0")
+    self.assertTrue((alternate_config / "mass_storage.1").is_symlink())
+    self.assertFalse((self.config / "mass_storage.0").is_symlink())
+    self.assertFalse((self.config / "ncm.0").is_symlink())
+    self.assertFalse((self.config / "ffs.adb").is_symlink())
+
+  def test_reenumeration_rejects_alternate_config_without_modifying_it(self) -> None:
+    self.adb_param.write_text("1\n")
+    self.run_helper("configure", "1")
+    (self.lun / "file").write_text("/run/usb-storage/footage.img\n")
+    foreign_function = self.gadget / "functions" / "mass_storage.1"
+    foreign_lun = foreign_function / "lun.0"
+    foreign_lun.mkdir(parents=True)
+    (foreign_lun / "file").write_text("/data/private.img\n")
+    alternate_config = self.gadget / "configs" / "c.2"
+    alternate_config.mkdir()
+    (alternate_config / "mass_storage.1").symlink_to(foreign_function)
+
+    result = self.run_helper("reenumerate-managed-storage", check=False)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertIn("more than configuration c.1", result.stderr)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertEqual(self.read(self.lun / "file"), "/run/usb-storage/footage.img")
+    self.assertEqual(self.read(foreign_lun / "file"), "/data/private.img")
+    self.assertTrue((alternate_config / "mass_storage.1").is_symlink())
+    self.assert_debug_links()
+
+  def test_regular_kernel_mass_storage_attributes_are_preserved(self) -> None:
+    self.adb_param.write_text("1\n")
+    self.run_helper("configure", "1")
+    num_buffers = self.mass_storage / "num_buffers"
+    num_buffers.write_text("4\n")
+
+    self.run_helper("configure", "1")
+    self.assertEqual(self.read(num_buffers), "4")
+    (self.lun / "file").write_text("/run/usb-storage/footage.img\n")
+
+    self.run_helper("reenumerate-managed-storage")
+
+    self.assertEqual(self.read(self.gadget / "UDC"), "a600000.dwc3")
+    self.assertEqual(self.read(num_buffers), "4")
+    self.assertEqual(self.read(self.lun / "file"), "/run/usb-storage/footage.img")
+    self.assert_debug_links()
+
   def test_clean_storage_stop_preserves_other_usb_functions(self) -> None:
     self.run_helper("configure", "1")
 

--- a/userspace/tests/test_usb_gadget.py
+++ b/userspace/tests/test_usb_gadget.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import signal
+import subprocess
+import tempfile
+import time
+import unittest  # noqa: TID251 - these tests intentionally use only the standard library
+
+
+USERSPACE = Path(__file__).parents[1]
+COMMA_DIR = USERSPACE / "root" / "usr" / "comma"
+GADGET_HELPER = COMMA_DIR / "usb_gadget.sh"
+SET_ADB = COMMA_DIR / "set_adb.sh"
+STOP_STORAGE = COMMA_DIR / "stop_usb_storage.sh"
+
+
+class UsbGadgetTest(unittest.TestCase):
+  def setUp(self) -> None:
+    self.temporary_directory = tempfile.TemporaryDirectory()
+    self.root = Path(self.temporary_directory.name)
+    self.configfs = self.root / "config"
+    self.gadget = self.configfs / "usb_gadget" / "g1"
+    self.config = self.gadget / "configs" / "c.1"
+    self.mass_storage = self.gadget / "functions" / "mass_storage.0"
+    self.lun = self.mass_storage / "lun.0"
+    self.link_log = self.root / "link-order.log"
+    self.link_wrapper = self.root / "logged-ln"
+    self.link_wrapper.write_text(
+      "#!/bin/sh\n"
+      "printf '%s\\n' \"${3##*/}\" >> \"$USB_GADGET_LINK_LOG\"\n"
+      "exec /bin/ln \"$@\"\n",
+    )
+    self.link_wrapper.chmod(0o755)
+
+    self.environment = os.environ.copy()
+    self.environment.update({
+      "USB_GADGET_CONFIGFS_ROOT": str(self.configfs),
+      "USB_GADGET_FFS_ADB_ROOT": str(self.root / "ffs-adb"),
+      "USB_GADGET_LOCK_FILE": str(self.root / "gadget.lock"),
+      "USB_GADGET_SERIAL": "test-serial",
+      "USB_GADGET_SKIP_MOUNTS": "1",
+      # macOS has no flock, while AGNOS gets it from util-linux. The real lock
+      # path is exercised by the Python manager tests; this tree is per-test.
+      "USB_GADGET_FLOCK_BIN": "/usr/bin/true",
+      "USB_GADGET_SYSTEMCTL_BIN": "/usr/bin/true",
+      "USB_GADGET_SETPROP_BIN": "/usr/bin/true",
+      "USB_GADGET_SLEEP_BIN": "/usr/bin/true",
+      "USB_GADGET_LN_BIN": str(self.link_wrapper),
+      "USB_GADGET_LINK_LOG": str(self.link_log),
+    })
+
+  def tearDown(self) -> None:
+    self.temporary_directory.cleanup()
+
+  def run_helper(self, *arguments: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+      [str(GADGET_HELPER), *arguments],
+      env=self.environment,
+      check=check,
+      capture_output=True,
+      text=True,
+    )
+
+  @staticmethod
+  def read(path: Path) -> str:
+    return path.read_text().strip()
+
+  def assert_non_adb_links(self) -> None:
+    self.assertTrue((self.config / "mass_storage.0").is_symlink())
+    self.assertTrue((self.config / "ncm.0").is_symlink())
+    self.assertFalse((self.config / "ffs.adb").is_symlink())
+
+  def assert_debug_links(self) -> None:
+    self.assertTrue((self.config / "mass_storage.0").is_symlink())
+    self.assertTrue((self.config / "ncm.0").is_symlink())
+    self.assertTrue((self.config / "ffs.adb").is_symlink())
+
+  def test_disabled_adb_exposes_network_and_empty_read_only_storage(self) -> None:
+    self.run_helper("configure", "0")
+
+    self.assertEqual(self.read(self.gadget / "UDC"), "a600000.dwc3")
+    self.assertEqual(self.read(self.gadget / "idVendor"), "0x04D8")
+    self.assertEqual(self.read(self.gadget / "idProduct"), "0x1234")
+    self.assertEqual(self.read(self.gadget / "strings" / "0x409" / "serialnumber"), "test-serial")
+    self.assertEqual(self.read(self.mass_storage / "stall"), "1")
+    self.assertEqual(self.read(self.lun / "ro"), "1")
+    self.assertEqual(self.read(self.lun / "removable"), "1")
+    self.assertEqual(self.read(self.lun / "file"), "")
+    self.assertEqual(self.read(self.config / "strings" / "0x409" / "configuration"), "NCM+Storage")
+    self.assert_non_adb_links()
+
+  def test_enabled_adb_adds_network_and_functionfs(self) -> None:
+    self.run_helper("configure", "1")
+
+    self.assertEqual(self.read(self.config / "strings" / "0x409" / "configuration"), "NCM+ADB+Storage")
+    self.assert_debug_links()
+
+  def test_function_order_preserves_existing_host_interface_numbers(self) -> None:
+    self.run_helper("configure", "0")
+    self.assertEqual(self.link_log.read_text().splitlines(), ["ncm.0", "mass_storage.0"])
+
+    self.link_log.write_text("")
+    self.run_helper("configure", "1")
+    self.assertEqual(self.link_log.read_text().splitlines(), ["ncm.0", "ffs.adb", "mass_storage.0"])
+
+  def test_reconfigure_ejects_populated_safe_lun(self) -> None:
+    self.run_helper("configure", "0")
+    (self.lun / "file").write_text("/run/usb-storage/footage.img\n")
+
+    self.run_helper("configure", "1")
+
+    self.assertEqual(self.read(self.lun / "file"), "")
+    self.assertEqual(self.read(self.lun / "ro"), "1")
+    self.assertEqual(self.read(self.lun / "removable"), "1")
+    self.assert_debug_links()
+
+  def test_unsafe_populated_lun_fails_unbound_and_unlinked(self) -> None:
+    self.run_helper("configure", "1")
+    (self.lun / "file").write_text("/run/usb-storage/footage.img\n")
+    (self.lun / "ro").write_text("0\n")
+
+    result = self.run_helper("configure", "0", check=False)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertIn("refusing to reconfigure", result.stderr)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertEqual(self.read(self.lun / "file"), "/run/usb-storage/footage.img")
+    self.assertFalse((self.config / "mass_storage.0").is_symlink())
+    self.assertFalse((self.config / "ncm.0").is_symlink())
+    self.assertFalse((self.config / "ffs.adb").is_symlink())
+
+  def test_foreign_read_only_lun_is_preserved_and_fails_unbound(self) -> None:
+    self.run_helper("configure", "0")
+    (self.lun / "file").write_text("/some/other/backing.img\n")
+
+    result = self.run_helper("configure", "1", check=False)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertIn("foreign", result.stderr)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertEqual(self.read(self.lun / "file"), "/some/other/backing.img")
+    self.assertFalse((self.config / "mass_storage.0").is_symlink())
+    self.assertFalse((self.config / "ncm.0").is_symlink())
+    self.assertFalse((self.config / "ffs.adb").is_symlink())
+
+  def test_repeated_configure_is_idempotent(self) -> None:
+    self.run_helper("configure", "0")
+    self.run_helper("configure", "0")
+    self.assert_non_adb_links()
+
+    self.run_helper("configure", "1")
+    self.run_helper("configure", "1")
+    self.assert_debug_links()
+    self.assertEqual(self.read(self.lun / "file"), "")
+
+  def test_bind_and_unbind_are_idempotent(self) -> None:
+    self.run_helper("configure", "0")
+
+    self.run_helper("unbind")
+    self.run_helper("unbind")
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assert_non_adb_links()
+
+    self.run_helper("bind")
+    self.run_helper("bind")
+    self.assertEqual(self.read(self.gadget / "UDC"), "a600000.dwc3")
+    self.assert_non_adb_links()
+
+  def test_symbolic_link_lock_is_rejected_without_touching_target(self) -> None:
+    lock = Path(self.environment["USB_GADGET_LOCK_FILE"])
+    victim = self.root / "victim"
+    victim.write_text("do not truncate")
+    lock.symlink_to(victim)
+
+    result = self.run_helper("configure", "0", check=False)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertIn("symbolic-link", result.stderr)
+    self.assertEqual(victim.read_text(), "do not truncate")
+    self.assertFalse(self.gadget.exists())
+
+  def test_set_adb_delegates_param_state(self) -> None:
+    adb_param = self.root / "AdbEnabled"
+    self.environment.update({
+      "USB_GADGET_ADB_PARAM": str(adb_param),
+      "USB_GADGET_HELPER": str(GADGET_HELPER),
+    })
+
+    adb_param.write_text("1")
+    subprocess.run([str(SET_ADB)], env=self.environment, check=True, capture_output=True, text=True)
+    self.assert_debug_links()
+
+    adb_param.write_text("0")
+    subprocess.run([str(SET_ADB)], env=self.environment, check=True, capture_output=True, text=True)
+    self.assert_non_adb_links()
+
+  def test_stop_wrapper_signals_manager_before_final_unbind(self) -> None:
+    event_log = self.root / "stop-order.log"
+    manager_script = self.root / "fake-manager.py"
+    manager_script.write_text(
+      "import os\n"
+      "from pathlib import Path\n"
+      "import signal\n"
+      "import time\n"
+      "log = Path(os.environ['USB_STORAGE_STOP_TEST_LOG'])\n"
+      "def stop(_signal, _frame):\n"
+      "  with log.open('a') as stream: stream.write('manager-exit\\n')\n"
+      "  raise SystemExit(0)\n"
+      "signal.signal(signal.SIGTERM, stop)\n"
+      "with log.open('a') as stream: stream.write('manager-ready\\n')\n"
+      "while True: time.sleep(1)\n",
+    )
+    helper = self.root / "fake-unbind"
+    helper.write_text(
+      "#!/bin/sh\n"
+      "printf 'unbind\\n' >> \"$USB_STORAGE_STOP_TEST_LOG\"\n",
+    )
+    helper.chmod(0o755)
+    environment = os.environ.copy()
+    environment.update({
+      "USB_GADGET_HELPER": str(helper),
+      "USB_STORAGE_STOP_TEST_LOG": str(event_log),
+      "USB_STORAGE_STOP_ATTEMPTS": "100",
+      "USB_STORAGE_KILL_ATTEMPTS": "5",
+      "USB_STORAGE_STOP_INTERVAL": "0.01",
+    })
+    process = subprocess.Popen(["python3", str(manager_script)], env=environment)
+    try:
+      deadline = time.monotonic() + 5
+      while (not event_log.exists() or "manager-ready" not in event_log.read_text()) and time.monotonic() < deadline:
+        time.sleep(0.01)
+      self.assertIsNone(process.poll())
+
+      subprocess.run(
+        [str(STOP_STORAGE), str(process.pid)],
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+      )
+
+      self.assertEqual(process.wait(timeout=2), 0)
+      self.assertEqual(event_log.read_text().splitlines(), ["manager-ready", "manager-exit", "unbind"])
+    finally:
+      if process.poll() is None:
+        process.send_signal(signal.SIGKILL)
+        process.wait(timeout=2)
+
+  def test_stop_wrapper_forces_manager_exit_before_final_unbind(self) -> None:
+    event_log = self.root / "forced-stop-order.log"
+    manager_script = self.root / "term-ignoring-manager.py"
+    manager_script.write_text(
+      "import os\n"
+      "from pathlib import Path\n"
+      "import signal\n"
+      "import time\n"
+      "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+      "Path(os.environ['USB_STORAGE_STOP_TEST_LOG']).write_text('manager-ready\\n')\n"
+      "while True: time.sleep(1)\n",
+    )
+    helper = self.root / "fake-forced-unbind"
+    helper.write_text(
+      "#!/bin/sh\n"
+      "printf 'unbind\\n' >> \"$USB_STORAGE_STOP_TEST_LOG\"\n",
+    )
+    helper.chmod(0o755)
+    environment = os.environ.copy()
+    environment.update({
+      "USB_GADGET_HELPER": str(helper),
+      "USB_STORAGE_STOP_TEST_LOG": str(event_log),
+      "USB_STORAGE_STOP_ATTEMPTS": "2",
+      "USB_STORAGE_KILL_ATTEMPTS": "2",
+      "USB_STORAGE_STOP_INTERVAL": "0.01",
+    })
+    process = subprocess.Popen(["python3", str(manager_script)], env=environment)
+    try:
+      deadline = time.monotonic() + 5
+      while (not event_log.exists() or "manager-ready" not in event_log.read_text()) and time.monotonic() < deadline:
+        time.sleep(0.01)
+      self.assertIsNone(process.poll())
+
+      result = subprocess.run(
+        [str(STOP_STORAGE), str(process.pid)],
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+      )
+
+      self.assertEqual(process.wait(timeout=2), -signal.SIGKILL)
+      self.assertIn("forcing main-process exit", result.stderr)
+      self.assertEqual(event_log.read_text().splitlines(), ["manager-ready", "unbind"])
+    finally:
+      if process.poll() is None:
+        process.send_signal(signal.SIGKILL)
+        process.wait(timeout=2)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/userspace/tests/test_usb_gadget.py
+++ b/userspace/tests/test_usb_gadget.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# ruff: noqa: ISC002 - adjacent literals keep embedded shell/Python fixtures readable
 
 from __future__ import annotations
 
@@ -16,6 +17,7 @@ COMMA_DIR = USERSPACE / "root" / "usr" / "comma"
 GADGET_HELPER = COMMA_DIR / "usb_gadget.sh"
 SET_ADB = COMMA_DIR / "set_adb.sh"
 STOP_STORAGE = COMMA_DIR / "stop_usb_storage.sh"
+STORAGE_SERVICE = USERSPACE / "root" / "usr" / "lib" / "systemd" / "system" / "usb-storage.service"
 
 
 class UsbGadgetTest(unittest.TestCase):
@@ -27,6 +29,7 @@ class UsbGadgetTest(unittest.TestCase):
     self.config = self.gadget / "configs" / "c.1"
     self.mass_storage = self.gadget / "functions" / "mass_storage.0"
     self.lun = self.mass_storage / "lun.0"
+    self.adb_param = self.root / "AdbEnabled"
     self.link_log = self.root / "link-order.log"
     self.link_wrapper = self.root / "logged-ln"
     self.link_wrapper.write_text(
@@ -42,6 +45,9 @@ class UsbGadgetTest(unittest.TestCase):
       "USB_GADGET_FFS_ADB_ROOT": str(self.root / "ffs-adb"),
       "USB_GADGET_LOCK_FILE": str(self.root / "gadget.lock"),
       "USB_GADGET_SERIAL": "test-serial",
+      "USB_GADGET_STORAGE_ONLY_VID": "0xCAFE",
+      "USB_GADGET_STORAGE_ONLY_PID": "0xBEEF",
+      "USB_GADGET_ADB_PARAM": str(self.adb_param),
       "USB_GADGET_SKIP_MOUNTS": "1",
       # macOS has no flock, while AGNOS gets it from util-linux. The real lock
       # path is exercised by the Python manager tests; this tree is per-test.
@@ -69,9 +75,9 @@ class UsbGadgetTest(unittest.TestCase):
   def read(path: Path) -> str:
     return path.read_text().strip()
 
-  def assert_non_adb_links(self) -> None:
+  def assert_storage_only_links(self) -> None:
     self.assertTrue((self.config / "mass_storage.0").is_symlink())
-    self.assertTrue((self.config / "ncm.0").is_symlink())
+    self.assertFalse((self.config / "ncm.0").is_symlink())
     self.assertFalse((self.config / "ffs.adb").is_symlink())
 
   def assert_debug_links(self) -> None:
@@ -79,33 +85,64 @@ class UsbGadgetTest(unittest.TestCase):
     self.assertTrue((self.config / "ncm.0").is_symlink())
     self.assertTrue((self.config / "ffs.adb").is_symlink())
 
-  def test_disabled_adb_exposes_network_and_empty_read_only_storage(self) -> None:
+  def test_disabled_adb_exposes_only_empty_read_only_storage(self) -> None:
     self.run_helper("configure", "0")
 
     self.assertEqual(self.read(self.gadget / "UDC"), "a600000.dwc3")
-    self.assertEqual(self.read(self.gadget / "idVendor"), "0x04D8")
-    self.assertEqual(self.read(self.gadget / "idProduct"), "0x1234")
+    self.assertEqual(self.read(self.gadget / "idVendor"), "0xCAFE")
+    self.assertEqual(self.read(self.gadget / "idProduct"), "0xBEEF")
     self.assertEqual(self.read(self.gadget / "strings" / "0x409" / "serialnumber"), "test-serial")
     self.assertEqual(self.read(self.mass_storage / "stall"), "1")
     self.assertEqual(self.read(self.lun / "ro"), "1")
     self.assertEqual(self.read(self.lun / "removable"), "1")
     self.assertEqual(self.read(self.lun / "file"), "")
-    self.assertEqual(self.read(self.config / "strings" / "0x409" / "configuration"), "NCM+Storage")
-    self.assert_non_adb_links()
+    self.assertEqual(self.read(self.config / "strings" / "0x409" / "configuration"), "Storage")
+    self.assert_storage_only_links()
 
   def test_enabled_adb_adds_network_and_functionfs(self) -> None:
     self.run_helper("configure", "1")
 
+    self.assertEqual(self.read(self.gadget / "idVendor"), "0x04D8")
+    self.assertEqual(self.read(self.gadget / "idProduct"), "0x1234")
     self.assertEqual(self.read(self.config / "strings" / "0x409" / "configuration"), "NCM+ADB+Storage")
     self.assert_debug_links()
 
   def test_function_order_preserves_existing_host_interface_numbers(self) -> None:
     self.run_helper("configure", "0")
-    self.assertEqual(self.link_log.read_text().splitlines(), ["ncm.0", "mass_storage.0"])
+    self.assertEqual(self.link_log.read_text().splitlines(), ["mass_storage.0"])
 
     self.link_log.write_text("")
     self.run_helper("configure", "1")
     self.assertEqual(self.link_log.read_text().splitlines(), ["ncm.0", "ffs.adb", "mass_storage.0"])
+
+  def test_storage_only_mode_requires_a_distinct_owner_approved_identity(self) -> None:
+    del self.environment["USB_GADGET_STORAGE_ONLY_VID"]
+    del self.environment["USB_GADGET_STORAGE_ONLY_PID"]
+    result = self.run_helper("configure", "0", check=False)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertIn("owner-approved", result.stderr)
+    self.assertFalse(self.gadget.exists())
+
+    self.environment["USB_GADGET_STORAGE_ONLY_VID"] = "0x04D8"
+    self.environment["USB_GADGET_STORAGE_ONLY_PID"] = "0x1234"
+    result = self.run_helper("configure", "0", check=False)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertIn("distinct", result.stderr)
+    self.assertFalse(self.gadget.exists())
+
+  def test_disabling_adb_without_approved_storage_identity_fails_unbound(self) -> None:
+    self.run_helper("configure", "1")
+    self.assertEqual(self.read(self.gadget / "UDC"), "a600000.dwc3")
+    del self.environment["USB_GADGET_STORAGE_ONLY_VID"]
+    del self.environment["USB_GADGET_STORAGE_ONLY_PID"]
+
+    result = self.run_helper("configure", "0", check=False)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertIn("owner-approved", result.stderr)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
 
   def test_reconfigure_ejects_populated_safe_lun(self) -> None:
     self.run_helper("configure", "0")
@@ -150,7 +187,7 @@ class UsbGadgetTest(unittest.TestCase):
   def test_repeated_configure_is_idempotent(self) -> None:
     self.run_helper("configure", "0")
     self.run_helper("configure", "0")
-    self.assert_non_adb_links()
+    self.assert_storage_only_links()
 
     self.run_helper("configure", "1")
     self.run_helper("configure", "1")
@@ -163,12 +200,138 @@ class UsbGadgetTest(unittest.TestCase):
     self.run_helper("unbind")
     self.run_helper("unbind")
     self.assertEqual(self.read(self.gadget / "UDC"), "")
-    self.assert_non_adb_links()
+    self.assert_storage_only_links()
 
     self.run_helper("bind")
     self.run_helper("bind")
     self.assertEqual(self.read(self.gadget / "UDC"), "a600000.dwc3")
-    self.assert_non_adb_links()
+    self.assert_storage_only_links()
+
+  def test_clean_storage_stop_preserves_other_usb_functions(self) -> None:
+    self.run_helper("configure", "1")
+
+    self.run_helper("finalize-storage-stop")
+
+    self.assertEqual(self.read(self.gadget / "UDC"), "a600000.dwc3")
+    self.assertEqual(self.read(self.lun / "file"), "")
+    self.assert_debug_links()
+
+  def test_storage_stop_reconstructs_requested_personality_after_fallback_unbind(self) -> None:
+    self.adb_param.write_text("1")
+    self.run_helper("configure", "1")
+    self.run_helper("unbind")
+
+    self.run_helper("finalize-storage-stop")
+
+    self.assertEqual(self.read(self.gadget / "UDC"), "a600000.dwc3")
+    self.assertEqual(self.read(self.gadget / "idVendor"), "0x04D8")
+    self.assertEqual(self.read(self.gadget / "idProduct"), "0x1234")
+    self.assert_debug_links()
+
+  def test_storage_stop_cannot_rebind_without_approved_requested_identity(self) -> None:
+    self.run_helper("configure", "1")
+    self.run_helper("unbind")
+    del self.environment["USB_GADGET_STORAGE_ONLY_VID"]
+    del self.environment["USB_GADGET_STORAGE_ONLY_PID"]
+
+    result = self.run_helper("finalize-storage-stop", check=False)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertIn("owner-approved", result.stderr)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+
+  def test_storage_stop_with_attached_media_leaves_gadget_unbound(self) -> None:
+    self.run_helper("configure", "1")
+    (self.lun / "file").write_text("/run/usb-storage/footage.img\n")
+
+    result = self.run_helper("finalize-storage-stop")
+
+    self.assertIn("media remains attached", result.stderr)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertEqual(self.read(self.lun / "file"), "/run/usb-storage/footage.img")
+    self.assert_debug_links()
+
+  def test_storage_start_clears_only_managed_media_before_rebinding(self) -> None:
+    self.adb_param.write_text("1")
+    self.run_helper("configure", "1")
+    (self.lun / "file").write_text("/run/usb-storage/footage.img\n")
+
+    self.run_helper("prepare-storage-start")
+
+    self.assertEqual(self.read(self.gadget / "UDC"), "a600000.dwc3")
+    self.assertEqual(self.read(self.lun / "file"), "")
+    self.assert_debug_links()
+
+    (self.lun / "file").write_text("/tmp/foreign.img\n")
+    result = self.run_helper("prepare-storage-start", check=False)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertIn("foreign", result.stderr)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertEqual(self.read(self.lun / "file"), "/tmp/foreign.img")
+
+  def test_failed_personality_transition_never_restores_mixed_identity(self) -> None:
+    self.run_helper("configure", "1")
+    failing_link = self.root / "failing-link"
+    failing_link.write_text("#!/bin/sh\nexit 1\n")
+    failing_link.chmod(0o755)
+    self.environment["USB_GADGET_LN_BIN"] = str(failing_link)
+
+    result = self.run_helper("configure", "0", check=False)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertEqual(self.read(self.gadget / "idVendor"), "0xCAFE")
+    self.assertEqual(self.read(self.gadget / "idProduct"), "0xBEEF")
+    self.assertFalse((self.config / "ncm.0").is_symlink())
+    self.assertFalse((self.config / "ffs.adb").is_symlink())
+    self.assertFalse((self.config / "mass_storage.0").is_symlink())
+
+    # A later service stop must not raw-bind this partial personality.
+    del self.environment["USB_GADGET_STORAGE_ONLY_VID"]
+    del self.environment["USB_GADGET_STORAGE_ONLY_PID"]
+    result = self.run_helper("finalize-storage-stop", check=False)
+    self.assertNotEqual(result.returncode, 0)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertFalse((self.config / "mass_storage.0").is_symlink())
+
+  def test_failed_transition_after_managed_lun_clear_stays_unbound(self) -> None:
+    self.run_helper("configure", "1")
+    (self.lun / "file").write_text("/run/usb-storage/footage.img\n")
+    failing_link = self.root / "failing-link-after-clear"
+    failing_link.write_text("#!/bin/sh\nexit 1\n")
+    failing_link.chmod(0o755)
+    self.environment["USB_GADGET_LN_BIN"] = str(failing_link)
+
+    result = self.run_helper("configure", "0", check=False)
+
+    self.assertNotEqual(result.returncode, 0)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertEqual(self.read(self.lun / "file"), "")
+    self.assertEqual(self.read(self.gadget / "idVendor"), "0xCAFE")
+    self.assertEqual(self.read(self.gadget / "idProduct"), "0xBEEF")
+    self.assertFalse((self.config / "ncm.0").is_symlink())
+    self.assertFalse((self.config / "ffs.adb").is_symlink())
+    self.assertFalse((self.config / "mass_storage.0").is_symlink())
+
+  def test_storage_start_reconstructs_instead_of_binding_partial_transition(self) -> None:
+    self.run_helper("configure", "1")
+    failing_link = self.root / "failing-link-before-start"
+    failing_link.write_text("#!/bin/sh\nexit 1\n")
+    failing_link.chmod(0o755)
+    self.environment["USB_GADGET_LN_BIN"] = str(failing_link)
+    result = self.run_helper("configure", "0", check=False)
+    self.assertNotEqual(result.returncode, 0)
+    self.assertEqual(self.read(self.gadget / "UDC"), "")
+    self.assertFalse((self.config / "mass_storage.0").is_symlink())
+
+    self.environment["USB_GADGET_LN_BIN"] = str(self.link_wrapper)
+    self.run_helper("prepare-storage-start")
+
+    self.assertEqual(self.read(self.gadget / "UDC"), "a600000.dwc3")
+    self.assertEqual(self.read(self.gadget / "idVendor"), "0xCAFE")
+    self.assertEqual(self.read(self.gadget / "idProduct"), "0xBEEF")
+    self.assert_storage_only_links()
 
   def test_symbolic_link_lock_is_rejected_without_touching_target(self) -> None:
     lock = Path(self.environment["USB_GADGET_LOCK_FILE"])
@@ -196,7 +359,17 @@ class UsbGadgetTest(unittest.TestCase):
 
     adb_param.write_text("0")
     subprocess.run([str(SET_ADB)], env=self.environment, check=True, capture_output=True, text=True)
-    self.assert_non_adb_links()
+    self.assert_storage_only_links()
+
+  def test_storage_service_reuses_adb_watcher_configuration(self) -> None:
+    unit = STORAGE_SERVICE.read_text()
+
+    self.assertIn("Requires=comma-init.service adb-param-watcher.service", unit)
+    self.assertNotIn("ExecStartPre=/usr/comma/set_adb.sh", unit)
+    self.assertLess(
+      unit.index("ExecStartPre=/usr/comma/usb_gadget.sh prepare-storage-start"),
+      unit.index("ExecStartPre=-/usr/bin/fusermount3 -uz /run/usb-storage"),
+    )
 
   def test_stop_wrapper_signals_manager_before_final_unbind(self) -> None:
     event_log = self.root / "stop-order.log"
@@ -217,7 +390,7 @@ class UsbGadgetTest(unittest.TestCase):
     helper = self.root / "fake-unbind"
     helper.write_text(
       "#!/bin/sh\n"
-      "printf 'unbind\\n' >> \"$USB_STORAGE_STOP_TEST_LOG\"\n",
+      "printf '%s\\n' \"$1\" >> \"$USB_STORAGE_STOP_TEST_LOG\"\n",
     )
     helper.chmod(0o755)
     environment = os.environ.copy()
@@ -244,7 +417,7 @@ class UsbGadgetTest(unittest.TestCase):
       )
 
       self.assertEqual(process.wait(timeout=2), 0)
-      self.assertEqual(event_log.read_text().splitlines(), ["manager-ready", "manager-exit", "unbind"])
+      self.assertEqual(event_log.read_text().splitlines(), ["manager-ready", "manager-exit", "finalize-storage-stop"])
     finally:
       if process.poll() is None:
         process.send_signal(signal.SIGKILL)
@@ -265,7 +438,7 @@ class UsbGadgetTest(unittest.TestCase):
     helper = self.root / "fake-forced-unbind"
     helper.write_text(
       "#!/bin/sh\n"
-      "printf 'unbind\\n' >> \"$USB_STORAGE_STOP_TEST_LOG\"\n",
+      "printf '%s\\n' \"$1\" >> \"$USB_STORAGE_STOP_TEST_LOG\"\n",
     )
     helper.chmod(0o755)
     environment = os.environ.copy()
@@ -293,7 +466,7 @@ class UsbGadgetTest(unittest.TestCase):
 
       self.assertEqual(process.wait(timeout=2), -signal.SIGKILL)
       self.assertIn("forcing main-process exit", result.stderr)
-      self.assertEqual(event_log.read_text().splitlines(), ["manager-ready", "unbind"])
+      self.assertEqual(event_log.read_text().splitlines(), ["manager-ready", "finalize-storage-stop"])
     finally:
       if process.poll() is None:
         process.send_signal(signal.SIGKILL)

--- a/userspace/tests/test_usb_storage.py
+++ b/userspace/tests/test_usb_storage.py
@@ -554,12 +554,26 @@ class ManagerTestBase(unittest.TestCase):
       "udc_state": self.udc_state,
       "gadget_lock": self.gadget_lock,
       "installation_validator": lambda: None,
+      # Unit-test mount files stand in for the nbdfuse FUSE mount. Tests that
+      # exercise a missing or racing mount override this checker explicitly.
+      "mount_checker": lambda _path: self.mount.exists(),
     }
     arguments.update(overrides)
     return usb_storage.StorageManager(**arguments)
 
 
 class StorageManagerTest(ManagerTestBase):
+  def test_mount_checker_uses_mountinfo_without_touching_dead_fuse_path(self) -> None:
+    mountinfo = self.root / "mountinfo"
+    mountinfo.write_text(
+      "36 35 0:32 / /run/usb-storage rw - fuse.nbdfuse nbdfuse rw\n",
+    )
+
+    with mock.patch.object(Path, "lstat", side_effect=OSError(errno.ENOTCONN, "dead FUSE")):
+      self.assertTrue(
+        usb_storage._mountpoint_is_listed(Path("/run/usb-storage"), mountinfo=mountinfo),
+      )
+
   def test_manager_cannot_raw_bind_gadget(self) -> None:
     commands: list[list[str]] = []
     manager = self.make_manager(command_runner=lambda command, **_kwargs: commands.append(command))
@@ -671,6 +685,10 @@ class StorageManagerTest(ManagerTestBase):
       captured[0],
       [
         "/usr/bin/nbdfuse",
+        "-o",
+        "fsname=nbdfuse",
+        "-o",
+        "subtype=nbdfuse",
         "-P",
         str(self.mount.parent.with_suffix(".pid")),
         str(self.mount),
@@ -719,6 +737,117 @@ class StorageManagerTest(ManagerTestBase):
         manager.export_started = False
         self.mount.unlink()
         manager.pidfile.unlink()
+
+  def test_readiness_timeout_without_fuse_mount_stops_child_and_cleans_snapshot(self) -> None:
+    current_time = [0.0]
+    events: list[str] = []
+
+    def process_factory(_command: list[str], **_kwargs: object) -> FakeProcess:
+      process = FakeProcess(events=events)
+      self.mount.parent.with_suffix(".pid").write_text(str(process.pid))
+      return process
+
+    manager = self.make_manager(
+      process_factory=process_factory,
+      mount_checker=lambda _path: False,
+      ready_timeout=0.2,
+      poll_interval=0.1,
+      clock=lambda: current_time[0],
+      sleep=lambda seconds: current_time.__setitem__(0, current_time[0] + seconds),
+      command_runner=lambda command, **_kwargs: events.append(f"unexpected-command-{command[0]}"),
+    )
+    manager.snapshot_builder.build()
+
+    with self.assertRaisesRegex(usb_storage.StorageError, "readiness"):
+      manager._start_export()
+
+    self.assertFalse(manager.teardown(rebind=False))
+    self.assertEqual(events, ["stop-child"])
+    self.assertIsNone(manager.process)
+    self.assertFalse(self.snapshot.exists())
+
+  def test_readiness_timeout_closes_mount_race_before_snapshot_cleanup(self) -> None:
+    current_time = [0.0]
+    mounted = [False]
+    events: list[str] = []
+
+    class LateMountProcess(FakeProcess):
+      def wait(inner_self, timeout: float | None = None) -> int:
+        mounted[0] = True
+        return super().wait(timeout)
+
+    def process_factory(_command: list[str], **_kwargs: object) -> LateMountProcess:
+      process = LateMountProcess(events=events)
+      self.mount.parent.with_suffix(".pid").write_text(str(process.pid))
+      return process
+
+    def command_runner(command: list[str], **_kwargs: object) -> types.SimpleNamespace:
+      self.assertEqual(command, ["/usr/bin/fusermount3", "-u", str(self.mount.parent)])
+      events.append("unmount")
+      mounted[0] = False
+      return types.SimpleNamespace(returncode=0)
+
+    manager = self.make_manager(
+      process_factory=process_factory,
+      mount_checker=lambda _path: mounted[0],
+      command_runner=command_runner,
+      ready_timeout=0.2,
+      poll_interval=0.1,
+      clock=lambda: current_time[0],
+      sleep=lambda seconds: current_time.__setitem__(0, current_time[0] + seconds),
+    )
+    manager.snapshot_builder.build()
+    original_cleanup = manager.snapshot_builder.cleanup
+
+    def cleanup() -> None:
+      events.append("remove-snapshot")
+      original_cleanup()
+
+    manager.snapshot_builder.cleanup = cleanup  # type: ignore[method-assign]
+
+    with self.assertRaisesRegex(usb_storage.StorageError, "readiness"):
+      manager._start_export()
+
+    self.assertFalse(manager.teardown(rebind=False))
+    self.assertEqual(events, ["stop-child", "unmount", "remove-snapshot"])
+    self.assertFalse(mounted[0])
+    self.assertFalse(self.snapshot.exists())
+
+  def test_readiness_timeout_after_fuse_mount_remains_fail_closed(self) -> None:
+    current_time = [0.0]
+    events: list[str] = []
+
+    def process_factory(_command: list[str], **_kwargs: object) -> FakeProcess:
+      process = FakeProcess(events=events)
+      self.mount.parent.mkdir(parents=True, exist_ok=True)
+      self.mount.write_bytes(b"wrong size")
+      self.mount.parent.with_suffix(".pid").write_text(str(process.pid))
+      return process
+
+    def failing_unmount(_command: list[str], **_kwargs: object) -> types.SimpleNamespace:
+      events.append("unmount")
+      return types.SimpleNamespace(returncode=1)
+
+    manager = self.make_manager(
+      process_factory=process_factory,
+      mount_checker=lambda _path: True,
+      command_runner=failing_unmount,
+      ready_timeout=0.2,
+      stop_timeout=0.2,
+      poll_interval=0.1,
+      clock=lambda: current_time[0],
+      sleep=lambda seconds: current_time.__setitem__(0, current_time[0] + seconds),
+    )
+    manager.snapshot_builder.build()
+
+    with self.assertRaisesRegex(usb_storage.StorageError, "readiness"):
+      manager._start_export()
+    with self.assertRaisesRegex(usb_storage.StorageError, "fusermount3"):
+      manager.teardown(rebind=False)
+
+    self.assertEqual(events, ["unmount", "unmount"])
+    self.assertIsNotNone(manager.process)
+    self.assertTrue(self.snapshot.exists())
 
   def test_lun_writes_require_existing_file_and_preserve_foreign_owner(self) -> None:
     manager = self.make_manager()
@@ -805,6 +934,7 @@ class StorageManagerTest(ManagerTestBase):
     self.mount.touch()
     manager.process = FakeProcess(events=events)
     manager.export_started = True
+    manager.fuse_mount_observed = True
     manager._set_lun()
 
     self.assertFalse(manager.teardown())
@@ -939,6 +1069,7 @@ class StorageManagerTest(ManagerTestBase):
     manager.snapshot_builder.cleanup = cleanup  # type: ignore[method-assign]
     manager.process = FakeProcess()
     manager.export_started = True
+    manager.fuse_mount_observed = True
 
     self.assertTrue(manager.teardown())
 
@@ -949,6 +1080,50 @@ class StorageManagerTest(ManagerTestBase):
         "unbind",
         "clear-lun",
         "unmount",
+        "stop-child",
+        "remove-snapshot",
+        "ensure-requested-personality",
+      ],
+    )
+    self.assertFalse(manager.forced_unbound)
+
+  def test_low_space_teardown_unbinds_before_clearing_lun(self) -> None:
+    events: list[str] = []
+
+    class LowSpaceManager(usb_storage.StorageManager):
+      def _run_gadget_helper(inner_self, action: str) -> None:
+        events.append(action)
+
+      def _clear_lun(inner_self) -> None:
+        events.append("clear-lun")
+
+      def _stop_child(inner_self) -> None:
+        events.append("stop-child")
+
+    manager = LowSpaceManager(
+      source=self.source,
+      snapshot=self.snapshot,
+      mount=self.mount,
+      lun=self.lun,
+      udc_state=self.udc_state,
+      gadget_lock=self.gadget_lock,
+      mount_checker=lambda _path: False,
+    )
+    manager.snapshot_builder.build()
+    original_cleanup = manager.snapshot_builder.cleanup
+
+    def cleanup() -> None:
+      events.append("remove-snapshot")
+      original_cleanup()
+
+    manager.snapshot_builder.cleanup = cleanup  # type: ignore[method-assign]
+
+    self.assertTrue(manager.teardown(force_unbind=True))
+    self.assertEqual(
+      events,
+      [
+        "unbind",
+        "clear-lun",
         "stop-child",
         "remove-snapshot",
         "ensure-requested-personality",
@@ -975,6 +1150,7 @@ class StorageManagerTest(ManagerTestBase):
     manager.snapshot_builder.build()
     manager.process = FakeProcess(events=events)
     manager.export_started = True
+    manager.fuse_mount_observed = True
     self.lun.write_text(f"{self.mount}\n")
 
     with self.assertRaisesRegex(usb_storage.StorageError, "fusermount3"):
@@ -1003,6 +1179,7 @@ class StorageManagerTest(ManagerTestBase):
     manager.snapshot_builder.build()
     manager.process = FakeProcess(events=events)
     manager.export_started = True
+    manager.fuse_mount_observed = True
     self.lun.write_text(f"{self.mount}\n")
 
     self.assertFalse(manager.teardown())
@@ -1107,6 +1284,31 @@ class StorageMonitorTest(ManagerTestBase):
     self.assertEqual(commands, ["reenumerate-managed-storage"])
     self.assertEqual(sleeps, [0.1, 0.1])
 
+  def test_reenumeration_stops_when_capacity_crosses_guarded_floor(self) -> None:
+    healthy = types.SimpleNamespace(
+      f_bavail=20 * 1024**3 // 4096,
+      f_frsize=4096,
+      f_blocks=100 * 1024**3 // 4096,
+    )
+    low = types.SimpleNamespace(
+      f_bavail=usb_storage.MIN_FREE_BYTES // 4096,
+      f_frsize=4096,
+      f_blocks=100 * 1024**3 // 4096,
+    )
+    statistics = iter((healthy, low))
+    commands: list[str] = []
+    manager = self.scripted_manager(
+      udc_states=["addressed"],
+      lun_values=[str(self.mount)],
+    )
+    manager.filesystem_stats = lambda _path: next(statistics)
+    manager.command_runner = lambda command, **_kwargs: (
+      commands.append(command[-1]) or types.SimpleNamespace(returncode=0)
+    )
+
+    self.assertEqual(manager._reenumerate_media(threading.Event()), usb_storage.SessionEnd.LOW_SPACE)
+    self.assertEqual(commands, ["reenumerate-managed-storage"])
+
   def test_reenumeration_wait_is_bounded_when_host_never_configures(self) -> None:
     current_time = [0.0]
     sleeps: list[float] = []
@@ -1171,6 +1373,45 @@ class StorageMonitorTest(ManagerTestBase):
     manager.filesystem_stats = lambda _path: stats
 
     self.assertEqual(manager.monitor(threading.Event()), usb_storage.SessionEnd.LOW_SPACE)
+
+  def test_export_capacity_has_margin_above_loggerd_floor(self) -> None:
+    self.assertGreater(usb_storage.MIN_FREE_BYTES, usb_storage.LOGGERD_MIN_FREE_BYTES)
+    self.assertGreater(usb_storage.MIN_FREE_PERCENT, usb_storage.LOGGERD_MIN_FREE_PERCENT)
+    self.assertEqual(
+      usb_storage.MIN_FREE_BYTES,
+      usb_storage.LOGGERD_MIN_FREE_BYTES + usb_storage.EXPORT_FREE_GUARD_BYTES,
+    )
+    self.assertEqual(
+      usb_storage.MIN_FREE_PERCENT,
+      usb_storage.LOGGERD_MIN_FREE_PERCENT + usb_storage.EXPORT_FREE_GUARD_PERCENT,
+    )
+
+    manager = self.scripted_manager(
+      udc_states=["configured"],
+      lun_values=[str(self.mount)],
+    )
+    exact_bytes = types.SimpleNamespace(
+      f_bavail=usb_storage.MIN_FREE_BYTES,
+      f_frsize=1,
+      f_blocks=2 * usb_storage.MIN_FREE_BYTES,
+    )
+    exact_percent = types.SimpleNamespace(
+      f_bavail=11_000_000,
+      f_frsize=1024,
+      f_blocks=100_000_000,
+    )
+    above_both = types.SimpleNamespace(
+      f_bavail=20_000_000,
+      f_frsize=1024,
+      f_blocks=100_000_000,
+    )
+
+    manager.filesystem_stats = lambda _path: exact_bytes
+    self.assertFalse(manager._has_export_capacity())
+    manager.filesystem_stats = lambda _path: exact_percent
+    self.assertFalse(manager._has_export_capacity())
+    manager.filesystem_stats = lambda _path: above_both
+    self.assertTrue(manager._has_export_capacity())
 
   def test_space_stat_failure_is_fail_closed(self) -> None:
     manager = self.scripted_manager(
@@ -1282,6 +1523,123 @@ class StorageMonitorTest(ManagerTestBase):
     self.assertFalse(self.mount.exists())
     self.assertFalse(manager.pidfile.exists())
 
+  def test_post_snapshot_capacity_recheck_prevents_export(self) -> None:
+    events: list[str] = []
+    stop_event = threading.Event()
+
+    class LowCapacityLifecycleManager(usb_storage.StorageManager):
+      def _wait_for_configured(inner_self, _event: threading.Event) -> bool:
+        return True
+
+      def _wait_for_source_while_attached(inner_self, _event: threading.Event) -> bool:
+        return True
+
+      def _has_export_capacity(inner_self) -> bool:
+        events.append(f"capacity-after-snapshot-{inner_self.snapshot_builder.snapshot.exists()}")
+        return False
+
+      def _read_udc_state(inner_self) -> str:
+        raise AssertionError("UDC must not be read after the low-space result")
+
+      def _start_export(inner_self) -> None:
+        raise AssertionError("export must not start below the guarded floor")
+
+      def _wait_for_physical_detach(
+        inner_self,
+        event: threading.Event,
+        *,
+        require_reconfigured: bool = False,
+      ) -> bool:
+        events.append(f"low-space-latch-reconfigured-{require_reconfigured}")
+        event.set()
+        return False
+
+    manager = LowCapacityLifecycleManager(
+      source=self.source,
+      snapshot=self.snapshot,
+      mount=self.mount,
+      lun=self.lun,
+      udc_state=self.udc_state,
+      gadget_lock=self.gadget_lock,
+      snapshot_wall_clock_ns=lambda: time.time_ns() + (3 * usb_storage.DEFAULT_STABILITY_AGE_NS),
+      mount_checker=lambda _path: False,
+    )
+    segment = self.source / "00000001--abc123def0--0"
+    segment.mkdir()
+    (segment / "qlog.zst").write_bytes(b"data")
+
+    self.assertEqual(manager.run(stop_event), 0)
+    self.assertEqual(events, ["capacity-after-snapshot-True", "low-space-latch-reconfigured-False"])
+    self.assertFalse(self.snapshot.exists())
+
+  def test_reenumeration_failure_rebuilds_personality_before_retry_latch(self) -> None:
+    events: list[str] = []
+    stop_event = threading.Event()
+
+    class ReenumerationFailureManager(usb_storage.StorageManager):
+      def _wait_for_configured(inner_self, _event: threading.Event) -> bool:
+        return True
+
+      def _wait_for_source_while_attached(inner_self, _event: threading.Event) -> bool:
+        return True
+
+      def _read_udc_state(inner_self) -> str:
+        return "configured"
+
+      def _has_export_capacity(inner_self) -> bool:
+        return True
+
+      def _start_export(inner_self) -> None:
+        events.append("start-export")
+
+      def _set_lun(inner_self) -> None:
+        events.append("set-lun")
+
+      def _run_gadget_helper(inner_self, action: str) -> None:
+        events.append(action)
+        if action == "reenumerate-managed-storage":
+          raise usb_storage.StorageError("validated re-enumeration failed")
+
+      def _wait_for_physical_detach(
+        inner_self,
+        event: threading.Event,
+        *,
+        require_reconfigured: bool = False,
+      ) -> bool:
+        events.append(f"failure-latch-reconfigured-{require_reconfigured}")
+        event.set()
+        return False
+
+    manager = ReenumerationFailureManager(
+      source=self.source,
+      snapshot=self.snapshot,
+      mount=self.mount,
+      lun=self.lun,
+      udc_state=self.udc_state,
+      gadget_lock=self.gadget_lock,
+      snapshot_wall_clock_ns=lambda: time.time_ns() + (3 * usb_storage.DEFAULT_STABILITY_AGE_NS),
+      mount_checker=lambda _path: False,
+    )
+    segment = self.source / "00000001--abc123def0--0"
+    segment.mkdir()
+    (segment / "qlog.zst").write_bytes(b"data")
+
+    with self.assertLogs("usb-storage", level="ERROR"):
+      self.assertEqual(manager.run(stop_event), 0)
+
+    self.assertEqual(
+      events,
+      [
+        "start-export",
+        "set-lun",
+        "reenumerate-managed-storage",
+        "ensure-requested-personality",
+        "failure-latch-reconfigured-True",
+      ],
+    )
+    self.assertFalse(manager.forced_unbound)
+    self.assertFalse(self.snapshot.exists())
+
   def test_startup_fallback_reconstructs_requested_personality(self) -> None:
     events: list[str] = []
 
@@ -1346,6 +1704,9 @@ class StorageMonitorTest(ManagerTestBase):
       def _read_udc_state(inner_self) -> str:
         return "configured"
 
+      def _has_export_capacity(inner_self) -> bool:
+        return True
+
       def _start_export(inner_self) -> None:
         inner_self.start_count += 1
         events.append("start-export")
@@ -1363,7 +1724,7 @@ class StorageMonitorTest(ManagerTestBase):
         events.append("monitor-detached")
         return usb_storage.SessionEnd.DETACHED
 
-      def teardown(inner_self, *, rebind: bool = True) -> bool:
+      def teardown(inner_self, *, rebind: bool = True, force_unbind: bool = False) -> bool:
         events.append("teardown")
         inner_self.snapshot_builder.cleanup()
         return inner_self.start_count == 1
@@ -1421,10 +1782,13 @@ class StorageMonitorTest(ManagerTestBase):
       def _wait_for_source_while_attached(inner_self, _event: threading.Event) -> bool:
         return True
 
+      def _has_export_capacity(inner_self) -> bool:
+        return True
+
       def _start_export(inner_self) -> None:
         raise OSError("export failed")
 
-      def teardown(inner_self, *, rebind: bool = True) -> None:
+      def teardown(inner_self, *, rebind: bool = True, force_unbind: bool = False) -> None:
         raise usb_storage.StorageError("cannot release backing state")
 
     manager = UnsafeTeardownManager(
@@ -1465,6 +1829,9 @@ class StorageMonitorTest(ManagerTestBase):
       def _read_udc_state(inner_self) -> str:
         return "configured"
 
+      def _has_export_capacity(inner_self) -> bool:
+        return True
+
       def _start_export(inner_self) -> None:
         events.append("start-export")
 
@@ -1480,12 +1847,18 @@ class StorageMonitorTest(ManagerTestBase):
         events.append(f"monitor-{end}")
         return end
 
-      def teardown(inner_self, *, rebind: bool = True) -> None:
+      def teardown(inner_self, *, rebind: bool = True, force_unbind: bool = False) -> bool:
         events.append("teardown")
         inner_self.snapshot_builder.cleanup()
+        return force_unbind
 
-      def _wait_for_physical_detach(inner_self, _event: threading.Event) -> bool:
-        events.append("eject-latch-until-detach")
+      def _wait_for_physical_detach(
+        inner_self,
+        _event: threading.Event,
+        *,
+        require_reconfigured: bool = False,
+      ) -> bool:
+        events.append(f"eject-latch-until-detach-reconfigured-{require_reconfigured}")
         return True
 
     manager = LifecycleManager(
@@ -1506,9 +1879,10 @@ class StorageMonitorTest(ManagerTestBase):
     self.assertEqual(events.count("set-lun"), 2)
     self.assertEqual(events.count("reenumerate-media"), 2)
     self.assertEqual(events.count("teardown"), 2)
-    self.assertEqual(events.count("eject-latch-until-detach"), 2)
+    self.assertEqual(events.count("eject-latch-until-detach-reconfigured-False"), 1)
+    self.assertEqual(events.count("eject-latch-until-detach-reconfigured-True"), 1)
     first_teardown = events.index("teardown")
-    latch = events.index("eject-latch-until-detach")
+    latch = events.index("eject-latch-until-detach-reconfigured-False")
     second_start = events.index("start-export", first_teardown + 1)
     self.assertLess(first_teardown, latch)
     self.assertLess(latch, second_start)

--- a/userspace/tests/test_usb_storage.py
+++ b/userspace/tests/test_usb_storage.py
@@ -560,6 +560,15 @@ class ManagerTestBase(unittest.TestCase):
 
 
 class StorageManagerTest(ManagerTestBase):
+  def test_manager_cannot_raw_bind_gadget(self) -> None:
+    commands: list[list[str]] = []
+    manager = self.make_manager(command_runner=lambda command, **_kwargs: commands.append(command))
+
+    with self.assertRaisesRegex(usb_storage.StorageError, "invalid gadget helper action"):
+      manager._run_gadget_helper("bind")
+
+    self.assertEqual(commands, [])
+
   def test_nbdkit_probe_requires_exact_supported_floppy_and_cow(self) -> None:
     command: list[str] = []
 
@@ -773,7 +782,7 @@ class StorageManagerTest(ManagerTestBase):
     manager.export_started = True
     manager._set_lun()
 
-    manager.teardown()
+    self.assertFalse(manager.teardown())
 
     self.assertEqual(events, ["clear-lun", "unmount", "stop-child", "remove-snapshot"])
     self.assertEqual(self.lun.read_text().strip(), "")
@@ -906,11 +915,19 @@ class StorageManagerTest(ManagerTestBase):
     manager.process = FakeProcess()
     manager.export_started = True
 
-    manager.teardown()
+    self.assertTrue(manager.teardown())
 
     self.assertEqual(
       events,
-      ["clear-lun", "unbind", "clear-lun", "unmount", "stop-child", "remove-snapshot", "bind"],
+      [
+        "clear-lun",
+        "unbind",
+        "clear-lun",
+        "unmount",
+        "stop-child",
+        "remove-snapshot",
+        "ensure-requested-personality",
+      ],
     )
     self.assertFalse(manager.forced_unbound)
 
@@ -1056,6 +1073,75 @@ class StorageMonitorTest(ManagerTestBase):
     self.assertFalse(manager._wait_for_configured(stop_event))
     self.assertEqual(sleeps, [1.0])
 
+  def test_physical_detach_ignores_transient_reenumeration(self) -> None:
+    current_time = [0.0]
+    sleeps: list[float] = []
+
+    def sleep(seconds: float) -> None:
+      sleeps.append(seconds)
+      current_time[0] += seconds
+
+    manager = self.scripted_manager(
+      udc_states=["not attached", "configured", "not attached", "not attached", "not attached"],
+      lun_values=[str(self.mount)],
+      sleep=sleep,
+    )
+    manager.clock = lambda: current_time[0]
+
+    self.assertTrue(manager._wait_for_physical_detach(threading.Event()))
+    self.assertEqual(sleeps, [1.0, 1.0, 1.0, 1.0])
+
+  def test_self_rebind_must_reconfigure_before_detach_can_unlock(self) -> None:
+    current_time = [0.0]
+    sleeps: list[float] = []
+
+    def sleep(seconds: float) -> None:
+      sleeps.append(seconds)
+      current_time[0] += seconds
+
+    manager = self.scripted_manager(
+      udc_states=[
+        "not attached",
+        "not attached",
+        "not attached",
+        "not attached",
+        "configured",
+        "not attached",
+        "not attached",
+        "not attached",
+      ],
+      lun_values=[str(self.mount)],
+      sleep=sleep,
+    )
+    manager.clock = lambda: current_time[0]
+
+    self.assertTrue(
+      manager._wait_for_physical_detach(
+        threading.Event(),
+        require_reconfigured=True,
+      ),
+    )
+    # The initial four-second disconnected interval was ignored. Only the
+    # stable detach after "configured" released the latch.
+    self.assertEqual(sleeps, [1.0] * 7)
+
+  def test_physical_detach_debounce_stops_promptly(self) -> None:
+    stop_event = threading.Event()
+    sleeps: list[float] = []
+
+    def stop_after_sleep(seconds: float) -> None:
+      sleeps.append(seconds)
+      stop_event.set()
+
+    manager = self.scripted_manager(
+      udc_states=["not attached"],
+      lun_values=[str(self.mount)],
+      sleep=stop_after_sleep,
+    )
+
+    self.assertFalse(manager._wait_for_physical_detach(stop_event))
+    self.assertEqual(sleeps, [1.0])
+
   def test_run_does_not_build_snapshot_before_attach(self) -> None:
     stop_event = threading.Event()
     self.udc_state.write_text("not attached\n")
@@ -1071,6 +1157,39 @@ class StorageMonitorTest(ManagerTestBase):
     self.assertFalse(self.mount.exists())
     self.assertFalse(manager.pidfile.exists())
 
+  def test_startup_fallback_reconstructs_requested_personality(self) -> None:
+    events: list[str] = []
+
+    class StartupFallbackManager(usb_storage.StorageManager):
+      clear_attempts = 0
+
+      def _clear_lun(inner_self) -> None:
+        inner_self.clear_attempts += 1
+        events.append("clear-lun")
+        if inner_self.clear_attempts == 1:
+          raise usb_storage.LunBusyError("prevented")
+
+      def _run_gadget_helper(inner_self, action: str) -> None:
+        events.append(action)
+
+    manager = StartupFallbackManager(
+      source=self.source,
+      snapshot=self.snapshot,
+      mount=self.mount,
+      lun=self.lun,
+      udc_state=self.udc_state,
+      gadget_lock=self.gadget_lock,
+    )
+    stop_event = threading.Event()
+    stop_event.set()
+
+    self.assertEqual(manager.run(stop_event), 0)
+    self.assertEqual(
+      events,
+      ["clear-lun", "unbind", "clear-lun", "ensure-requested-personality"],
+    )
+    self.assertFalse(manager.forced_unbound)
+
   def test_missing_realdata_at_service_start_is_not_fatal(self) -> None:
     self.source.rmdir()
     stop_event = threading.Event()
@@ -1078,6 +1197,120 @@ class StorageMonitorTest(ManagerTestBase):
 
     self.assertFalse(manager._wait_for_source_while_attached(stop_event))
     self.assertFalse(self.snapshot.exists())
+
+  def test_session_error_latches_until_detach_then_recovers(self) -> None:
+    events: list[str] = []
+    stop_event = threading.Event()
+
+    class RecoveringLifecycleManager(usb_storage.StorageManager):
+      wait_count = 0
+      start_count = 0
+
+      def _wait_for_configured(inner_self, event: threading.Event) -> bool:
+        inner_self.wait_count += 1
+        events.append("wait-configured")
+        if inner_self.wait_count <= 2:
+          return True
+        event.set()
+        return False
+
+      def _wait_for_source_while_attached(inner_self, _event: threading.Event) -> bool:
+        events.append("source-ready")
+        return True
+
+      def _read_udc_state(inner_self) -> str:
+        return "configured"
+
+      def _start_export(inner_self) -> None:
+        inner_self.start_count += 1
+        events.append("start-export")
+        if inner_self.start_count == 1:
+          raise OSError("transient exporter failure")
+
+      def _set_lun(inner_self) -> None:
+        events.append("set-lun")
+
+      def monitor(inner_self, _event: threading.Event) -> usb_storage.SessionEnd:
+        events.append("monitor-detached")
+        return usb_storage.SessionEnd.DETACHED
+
+      def teardown(inner_self, *, rebind: bool = True) -> bool:
+        events.append("teardown")
+        inner_self.snapshot_builder.cleanup()
+        return inner_self.start_count == 1
+
+      def _wait_for_physical_detach(
+        inner_self,
+        _event: threading.Event,
+        *,
+        require_reconfigured: bool = False,
+      ) -> bool:
+        events.append(f"failure-latch-until-detach-reconfigured-{require_reconfigured}")
+        return True
+
+    manager = RecoveringLifecycleManager(
+      source=self.source,
+      snapshot=self.snapshot,
+      mount=self.mount,
+      lun=self.lun,
+      udc_state=self.udc_state,
+      gadget_lock=self.gadget_lock,
+      snapshot_wall_clock_ns=lambda: time.time_ns() + (3 * usb_storage.DEFAULT_STABILITY_AGE_NS),
+    )
+    segment = self.source / "00000001--abc123def0--0"
+    segment.mkdir()
+    (segment / "qlog.zst").write_bytes(b"data")
+
+    with self.assertLogs("usb-storage", level="ERROR") as logs:
+      self.assertEqual(manager.run(stop_event), 1)
+
+    self.assertIn("transient exporter failure", "\n".join(logs.output))
+    self.assertEqual(
+      events,
+      [
+        "wait-configured",
+        "source-ready",
+        "start-export",
+        "teardown",
+        "failure-latch-until-detach-reconfigured-True",
+        "wait-configured",
+        "source-ready",
+        "start-export",
+        "set-lun",
+        "monitor-detached",
+        "teardown",
+        "wait-configured",
+      ],
+    )
+
+  def test_session_error_propagates_when_teardown_fails(self) -> None:
+    class UnsafeTeardownManager(usb_storage.StorageManager):
+      def _wait_for_configured(inner_self, _event: threading.Event) -> bool:
+        return True
+
+      def _wait_for_source_while_attached(inner_self, _event: threading.Event) -> bool:
+        return True
+
+      def _start_export(inner_self) -> None:
+        raise OSError("export failed")
+
+      def teardown(inner_self, *, rebind: bool = True) -> None:
+        raise usb_storage.StorageError("cannot release backing state")
+
+    manager = UnsafeTeardownManager(
+      source=self.source,
+      snapshot=self.snapshot,
+      mount=self.mount,
+      lun=self.lun,
+      udc_state=self.udc_state,
+      gadget_lock=self.gadget_lock,
+    )
+
+    with self.assertLogs("usb-storage", level="ERROR"):
+      with self.assertRaisesRegex(usb_storage.StorageError, "cannot release backing state") as raised:
+        manager.run(threading.Event())
+
+    self.assertIsInstance(raised.exception.__cause__, OSError)
 
   def test_eject_and_low_space_latch_before_reinsertion(self) -> None:
     events: list[str] = []

--- a/userspace/tests/test_usb_storage.py
+++ b/userspace/tests/test_usb_storage.py
@@ -403,6 +403,19 @@ class Fat32CompatibilityTest(unittest.TestCase):
     self.assertGreater(disk_size, 3 * 1024**3)
     self.assertEqual(total_clusters - 65 - 2 * fat_clusters, used_clusters)
 
+  def test_layout_rejects_file_truncated_after_snapshot(self) -> None:
+    footage = self.root / "rlog.zst"
+    footage.write_bytes(b"complete")
+    self.assertEqual(
+      usb_storage._nbdkit_layout(self.root),
+      (usb_storage.MIN_COMPATIBLE_DISK_SIZE, usb_storage.MIN_COMPATIBLE_DISK_SIZE),
+    )
+
+    footage.write_bytes(b"")
+
+    with self.assertRaisesRegex(usb_storage.StorageError, "empty file unsupported"):
+      usb_storage._nbdkit_layout(self.root)
+
   def test_repairs_primary_backup_and_root_child_dotdot_idempotently(self) -> None:
     image = self.root / "footage.img"
     partition_offset, data_offset = make_nbdkit_fat32_image(image)

--- a/userspace/tests/test_usb_storage.py
+++ b/userspace/tests/test_usb_storage.py
@@ -14,7 +14,7 @@ import threading
 import time
 import types
 import unittest  # noqa: TID251 - these tests intentionally use only the standard library
-from unittest import mock
+from unittest import mock  # noqa: TID251 - these tests intentionally use only the standard library
 
 
 COMMA_DIR = Path(__file__).parents[1] / "root" / "usr" / "comma"
@@ -553,12 +553,67 @@ class ManagerTestBase(unittest.TestCase):
       "lun": self.lun,
       "udc_state": self.udc_state,
       "gadget_lock": self.gadget_lock,
+      "installation_validator": lambda: None,
     }
     arguments.update(overrides)
     return usb_storage.StorageManager(**arguments)
 
 
 class StorageManagerTest(ManagerTestBase):
+  def test_nbdkit_probe_requires_exact_supported_floppy_and_cow(self) -> None:
+    command: list[str] = []
+
+    def runner(arguments: list[str], **_kwargs: object) -> object:
+      command.extend(arguments)
+      return types.SimpleNamespace(
+        returncode=0,
+        stdout="name=floppy\nversion=1.36.3\ncow_name=cow\n",
+      )
+
+    usb_storage._validate_nbdkit_installation(runner)
+    self.assertEqual(command, ["/usr/bin/nbdkit", "--filter=cow", "floppy", "--dump-plugin"])
+
+    for output in (
+      "name=floppy\nversion=1.38.0\ncow_name=cow\n",
+      "name=floppy\nversion=1.36.3\n",
+      "malformed output",
+    ):
+      with self.subTest(output=output):
+        with self.assertRaises(usb_storage.StorageError):
+          usb_storage._validate_nbdkit_installation(
+            lambda _arguments, output=output, **_kwargs: types.SimpleNamespace(returncode=0, stdout=output),
+          )
+
+    with self.assertRaises(usb_storage.StorageError):
+      usb_storage._validate_nbdkit_installation(
+        lambda _arguments, **_kwargs: types.SimpleNamespace(returncode=1, stdout=""),
+      )
+
+  def test_nbdkit_probe_is_cached_after_first_export(self) -> None:
+    probes: list[bool] = []
+
+    def process_factory(_command: list[str], **_kwargs: object) -> FakeProcess:
+      process = FakeProcess()
+      self.mount.parent.mkdir(parents=True, exist_ok=True)
+      with self.mount.open("wb") as virtual_disk:
+        virtual_disk.truncate(usb_storage.MIN_COMPATIBLE_DISK_SIZE)
+      self.mount.parent.with_suffix(".pid").write_text(str(process.pid))
+      return process
+
+    manager = self.make_manager(
+      process_factory=process_factory,
+      image_repairer=lambda _path: None,
+      installation_validator=lambda: probes.append(True),
+    )
+    manager.snapshot_builder.build()
+    manager._start_export()
+    manager.process = None
+    manager.export_started = False
+    manager._prepare_mount()
+    manager._start_export()
+
+    self.assertEqual(probes, [True])
+
   def test_nbdfuse_command_uses_cow_repair_and_exact_virtual_size(self) -> None:
     captured: list[list[str]] = []
     captured_environment: list[dict[str, str]] = []
@@ -986,13 +1041,20 @@ class StorageMonitorTest(ManagerTestBase):
 
   def test_wait_for_attach_is_idle_until_stopped(self) -> None:
     stop_event = threading.Event()
+    sleeps: list[float] = []
+
+    def stop_after_sleep(seconds: float) -> None:
+      sleeps.append(seconds)
+      stop_event.set()
+
     manager = self.scripted_manager(
       udc_states=["attached"],
       lun_values=[str(self.mount)],
-      sleep=lambda _seconds: stop_event.set(),
+      sleep=stop_after_sleep,
     )
 
     self.assertFalse(manager._wait_for_configured(stop_event))
+    self.assertEqual(sleeps, [1.0])
 
   def test_run_does_not_build_snapshot_before_attach(self) -> None:
     stop_event = threading.Event()

--- a/userspace/tests/test_usb_storage.py
+++ b/userspace/tests/test_usb_storage.py
@@ -1,0 +1,1032 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import errno
+import os
+from pathlib import Path
+import stat
+import struct
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import types
+import unittest  # noqa: TID251 - these tests intentionally use only the standard library
+
+
+COMMA_DIR = Path(__file__).parents[1] / "root" / "usr" / "comma"
+sys.path.insert(0, str(COMMA_DIR))
+
+import usb_storage  # noqa: E402, RUF100
+
+
+class SnapshotBuilderTest(unittest.TestCase):
+  def setUp(self) -> None:
+    self.temporary_directory = tempfile.TemporaryDirectory()
+    self.root = Path(self.temporary_directory.name)
+    self.source = self.root / "realdata"
+    self.source.mkdir()
+    self.snapshot = self.root / usb_storage.MANAGED_SNAPSHOT_NAME
+    self.snapshot_time_ns = time.time_ns() + (3 * usb_storage.DEFAULT_STABILITY_AGE_NS)
+
+  def tearDown(self) -> None:
+    # Snapshot directories intentionally become read-only. Builder cleanup also
+    # exercises the guarded permission restoration used on the device.
+    if self.snapshot.exists():
+      usb_storage.SnapshotBuilder(self.source, self.snapshot).cleanup()
+    self.temporary_directory.cleanup()
+
+  def make_segment(self, name: str) -> Path:
+    segment = self.source / name
+    segment.mkdir(parents=True)
+    return segment
+
+  def builder(self) -> usb_storage.SnapshotBuilder:
+    return usb_storage.SnapshotBuilder(
+      self.source,
+      self.snapshot,
+      wall_clock_ns=lambda: self.snapshot_time_ns,
+    )
+
+  def test_snapshot_is_hard_link_and_survives_original_unlink(self) -> None:
+    segment = self.make_segment("00000001--abc123def0--0")
+    (segment / "nested").mkdir()
+    original = segment / "nested" / "fcamera.hevc"
+    original.write_bytes(b"finished footage")
+
+    result = self.builder().build()
+    linked = self.snapshot / segment.name / "nested" / original.name
+
+    self.assertEqual(result.included, (segment.name,))
+    self.assertEqual(result.excluded, ())
+    self.assertEqual(original.stat().st_ino, linked.stat().st_ino)
+    self.assertEqual(original.stat().st_dev, linked.stat().st_dev)
+    self.assertFalse(stat.S_IMODE(self.snapshot.stat().st_mode) & stat.S_IWUSR)
+
+    original.unlink()
+    self.assertEqual(linked.read_bytes(), b"finished footage")
+
+  def test_active_lock_excludes_entire_segment(self) -> None:
+    finished = self.make_segment("00000001--abc123def0--0")
+    (finished / "rlog.zst").write_bytes(b"done")
+    active = self.make_segment("00000001--abc123def0--1")
+    (active / "fcamera.hevc").write_bytes(b"partial")
+    (active / "rlog.lock").touch()
+
+    result = self.builder().build()
+
+    self.assertEqual(result.included, (finished.name,))
+    self.assertEqual(result.excluded[0][0], active.name)
+    self.assertIn("active lock", result.excluded[0][1])
+    self.assertFalse((self.snapshot / active.name).exists())
+
+  def test_symlink_oversize_and_nonregular_trees_are_excluded(self) -> None:
+    symlink_segment = self.make_segment("00000001--abc123def0--0")
+    target = self.root / "private"
+    target.write_text("must not leak")
+    (symlink_segment / "camera").symlink_to(target)
+
+    oversize_segment = self.make_segment("00000001--abc123def0--1")
+    with (oversize_segment / "fcamera.hevc").open("wb") as oversized:
+      oversized.truncate(usb_storage.MAX_FAT_FILE_SIZE)
+
+    fifo_segment = self.make_segment("00000001--abc123def0--2")
+    os.mkfifo(fifo_segment / "unexpected.pipe")
+
+    result = self.builder().build()
+    reasons = dict(result.excluded)
+
+    self.assertEqual(result.included, ())
+    self.assertIn("symbolic link", reasons[symlink_segment.name])
+    self.assertIn("too large", reasons[oversize_segment.name])
+    self.assertIn("non-regular", reasons[fifo_segment.name])
+    self.assertEqual(list(self.snapshot.iterdir()), [])
+
+  def test_empty_file_excludes_entire_segment(self) -> None:
+    segment = self.make_segment("00000001--abc123def0--0")
+    (segment / "rlog.zst").write_bytes(b"complete log")
+    (segment / "empty.hevc").touch()
+
+    result = self.builder().build()
+
+    self.assertEqual(result.included, ())
+    self.assertIn("empty file unsupported", result.excluded[0][1])
+    self.assertFalse((self.snapshot / segment.name).exists())
+
+  def test_unrelated_and_nested_directories_are_ignored(self) -> None:
+    route = self.source / "dongle|2026-08-22--12-00-00"
+    nested = route / "0"
+    nested.mkdir(parents=True)
+    (nested / "qlog.zst").write_bytes(b"must not export")
+    unrelated = self.source / "boot"
+    unrelated.mkdir()
+    (unrelated / "bootlog.zst").write_bytes(b"must not export")
+
+    result = self.builder().build()
+
+    self.assertEqual(result.included, ())
+    self.assertEqual(result.excluded, ())
+    self.assertEqual(list(self.snapshot.iterdir()), [])
+
+  def test_windows_and_vfat_unsafe_names_are_rejected(self) -> None:
+    unsafe_names = (
+      "bad?.hevc",
+      "bad<name",
+      "trailing.",
+      "trailing ",
+      "CON",
+      "con.txt",
+      "COM9.log",
+      "LPT1",
+      "control\x01name",
+      "delete\x7fname",
+      "control\x85name",
+      "a" * 256,
+      "😀" * 128,
+      "invalid-surrogate-\udcff",
+    )
+    for name in unsafe_names:
+      with self.subTest(name=repr(name)):
+        with self.assertRaises(usb_storage.UnsafeTreeError):
+          usb_storage._validate_portable_name(name)
+
+    for name in ("fcamera.hevc", "00000001--abc123def0--0", "café.txt"):
+      with self.subTest(valid_name=name):
+        usb_storage._validate_portable_name(name)
+
+  def test_unsafe_component_excludes_entire_segment(self) -> None:
+    segment = self.make_segment("00000001--abc123def0--0")
+    (segment / "CON.txt").write_bytes(b"reserved name")
+
+    result = self.builder().build()
+
+    self.assertEqual(result.included, ())
+    self.assertIn("reserved DOS", result.excluded[0][1])
+    self.assertFalse((self.snapshot / segment.name).exists())
+
+  def test_unrecognized_top_level_segment_name_is_ignored(self) -> None:
+    segment = self.make_segment("bad:route--0")
+    (segment / "rlog.zst").write_bytes(b"data")
+
+    result = self.builder().build()
+
+    self.assertEqual(result.included, ())
+    self.assertEqual(result.excluded, ())
+
+  def test_legacy_route_separator_is_exported_with_portable_name(self) -> None:
+    segment = self.make_segment("a2a0ccea32023010|2026-08-23--12-34-56--0")
+    (segment / "rlog.zst").write_bytes(b"legacy route")
+
+    result = self.builder().build()
+    portable_name = segment.name.replace("|", "_")
+
+    self.assertEqual(result.included, (portable_name,))
+    self.assertEqual((self.snapshot / portable_name / "rlog.zst").read_bytes(), b"legacy route")
+    self.assertFalse((self.snapshot / segment.name).exists())
+
+  def test_portable_segment_name_collision_excludes_both_sources(self) -> None:
+    legacy = self.make_segment("a2a0ccea32023010|2026-08-23--12-34-56--0")
+    alternate = self.make_segment("a2a0ccea32023010_2026-08-23--12-34-56--0")
+    (legacy / "rlog.zst").write_bytes(b"legacy")
+    (alternate / "rlog.zst").write_bytes(b"alternate")
+
+    result = self.builder().build()
+
+    self.assertEqual(result.included, ())
+    self.assertEqual({name for name, _reason in result.excluded}, {legacy.name, alternate.name})
+    self.assertTrue(all("collides" in reason for _name, reason in result.excluded))
+    self.assertEqual(list(self.snapshot.iterdir()), [])
+
+  def test_just_unlocked_segment_is_excluded_until_stability_age(self) -> None:
+    now_ns = time.time_ns()
+    recent = self.make_segment("00000001--abc123def0--0")
+    (recent / "rlog.zst").write_bytes(b"final compressed bytes")
+    lock = recent / "rlog.lock"
+    lock.touch()
+    lock.unlink()
+
+    aged = self.make_segment("00000001--abc123def0--1")
+    aged_file = aged / "rlog.zst"
+    aged_file.write_bytes(b"stable bytes")
+    aged_mtime_ns = now_ns - usb_storage.DEFAULT_STABILITY_AGE_NS - 1
+    os.utime(aged_file, ns=(aged_mtime_ns, aged_mtime_ns))
+    os.utime(aged, ns=(aged_mtime_ns, aged_mtime_ns))
+
+    recent_file = self.make_segment("00000001--abc123def0--2")
+    (recent_file / "rlog.zst").write_bytes(b"still flushing")
+    os.utime(recent_file, ns=(aged_mtime_ns, aged_mtime_ns))
+
+    result = usb_storage.SnapshotBuilder(
+      self.source,
+      self.snapshot,
+      wall_clock_ns=lambda: now_ns,
+    ).build()
+    reasons = dict(result.excluded)
+
+    self.assertEqual(result.included, (aged.name,))
+    self.assertIn("too recent", reasons[recent.name])
+    self.assertIn("too recent", reasons[recent_file.name])
+    self.assertFalse((self.snapshot / recent.name).exists())
+    self.assertTrue((self.snapshot / aged.name / "rlog.zst").is_file())
+
+  def test_refuses_any_broad_or_unmanaged_cleanup_destination(self) -> None:
+    for unsafe in (self.root, self.source, self.root / "some-other-name"):
+      with self.subTest(unsafe=unsafe):
+        with self.assertRaises(usb_storage.StorageError):
+          usb_storage.SnapshotBuilder(self.source, unsafe)
+
+  def test_refuses_symlink_at_managed_destination(self) -> None:
+    victim = self.root / "victim"
+    victim.mkdir()
+    self.snapshot.symlink_to(victim, target_is_directory=True)
+
+    with self.assertRaises(usb_storage.StorageError):
+      usb_storage.SnapshotBuilder(self.source, self.snapshot).build()
+    self.assertTrue(victim.is_dir())
+    self.snapshot.unlink()
+
+  def test_source_replaced_by_symlink_after_start_is_refused(self) -> None:
+    builder = self.builder()
+    original = self.root / "original-realdata"
+    self.source.rename(original)
+    self.source.symlink_to(original, target_is_directory=True)
+
+    with self.assertRaisesRegex(usb_storage.StorageError, "symbolic link"):
+      builder.build()
+
+    self.source.unlink()
+    original.rename(self.source)
+
+  def test_snapshot_parent_redirect_after_start_is_refused(self) -> None:
+    snapshot_parent = self.root / "snapshot-parent"
+    snapshot_parent.mkdir()
+    requested_snapshot = snapshot_parent / usb_storage.MANAGED_SNAPSHOT_NAME
+    builder = usb_storage.SnapshotBuilder(self.source, requested_snapshot)
+    original_parent = self.root / "original-snapshot-parent"
+    replacement_parent = self.root / "replacement-snapshot-parent"
+    replacement_parent.mkdir()
+    snapshot_parent.rename(original_parent)
+    snapshot_parent.symlink_to(replacement_parent, target_is_directory=True)
+
+    with self.assertRaisesRegex(usb_storage.StorageError, "real directory|resolution changed"):
+      builder.cleanup()
+
+    snapshot_parent.unlink()
+    original_parent.rename(snapshot_parent)
+
+
+def make_nbdkit_fat32_image(path: Path) -> tuple[int, int]:
+  image_size = usb_storage.MIN_COMPATIBLE_DISK_SIZE
+  partition_lba = 2048
+  partition_sectors = (image_size // usb_storage.SECTOR_SIZE) - partition_lba
+  total_clusters = image_size // usb_storage.FAT_CLUSTER_SIZE
+  fat_clusters = (total_clusters - 63 + 4095) // 4096
+  sectors_per_fat = fat_clusters * (usb_storage.FAT_CLUSTER_SIZE // usb_storage.SECTOR_SIZE)
+  partition_offset = partition_lba * usb_storage.SECTOR_SIZE
+  data_offset = partition_offset + (32 + 2 * sectors_per_fat) * usb_storage.SECTOR_SIZE
+
+  mbr = bytearray(usb_storage.SECTOR_SIZE)
+  mbr[446 + 4] = 0x0C
+  struct.pack_into("<II", mbr, 446 + 8, partition_lba, partition_sectors)
+  mbr[510:512] = b"\x55\xaa"
+
+  boot = bytearray(usb_storage.SECTOR_SIZE)
+  boot[3:11] = b"MSWIN4.1"
+  struct.pack_into("<H", boot, 11, usb_storage.SECTOR_SIZE)
+  boot[13] = usb_storage.FAT_CLUSTER_SIZE // usb_storage.SECTOR_SIZE
+  struct.pack_into("<H", boot, 14, 32)
+  boot[16] = 2
+  boot[21] = 0xF8
+  struct.pack_into("<I", boot, 32, partition_sectors)
+  struct.pack_into("<I", boot, 36, sectors_per_fat)
+  struct.pack_into("<I", boot, 44, 2)
+  struct.pack_into("<H", boot, 48, 1)
+  struct.pack_into("<H", boot, 50, 6)
+  boot[66] = 0x29
+  boot[71:82] = b"COMMA      "
+  boot[82:90] = b"FAT32   "
+  boot[510:512] = b"\x55\xaa"
+
+  fat = bytearray(usb_storage.FAT_CLUSTER_SIZE)
+  for cluster, value in enumerate((0x0FFFFFF8, 0xFFFFFFFF, 0x0FFFFFFF, 0x0FFFFFFF, 0x0FFFFFFF)):
+    struct.pack_into("<I", fat, cluster * 4, value)
+
+  root = bytearray(usb_storage.FAT_CLUSTER_SIZE)
+  root[0:11] = b"COMMA      "
+  root[11] = 0x08
+  root[32:43] = b"SEGMENT    "
+  root[43] = 0x10
+  struct.pack_into("<H", root, 32 + 26, 3)
+
+  child = bytearray(usb_storage.FAT_CLUSTER_SIZE)
+  child[0:11] = b".          "
+  child[11] = 0x10
+  struct.pack_into("<H", child, 26, 3)
+  child[32:43] = b"..         "
+  child[43] = 0x10
+  struct.pack_into("<H", child, 32 + 26, 2)
+  child[64:75] = b"NESTED     "
+  child[75] = 0x10
+  struct.pack_into("<H", child, 64 + 26, 4)
+
+  nested = bytearray(usb_storage.FAT_CLUSTER_SIZE)
+  nested[0:11] = b".          "
+  nested[11] = 0x10
+  struct.pack_into("<H", nested, 26, 4)
+  nested[32:43] = b"..         "
+  nested[43] = 0x10
+  struct.pack_into("<H", nested, 32 + 26, 3)
+
+  with path.open("wb") as image:
+    image.truncate(image_size)
+    for offset, data in (
+      (0, mbr),
+      (partition_offset, boot),
+      (partition_offset + 6 * usb_storage.SECTOR_SIZE, boot),
+      (partition_offset + 32 * usb_storage.SECTOR_SIZE, fat),
+      (partition_offset + (32 + sectors_per_fat) * usb_storage.SECTOR_SIZE, fat),
+      (data_offset, root),
+      (data_offset + usb_storage.FAT_CLUSTER_SIZE, child),
+      (data_offset + 2 * usb_storage.FAT_CLUSTER_SIZE, nested),
+    ):
+      image.seek(offset)
+      image.write(data)
+  return partition_offset, data_offset
+
+
+class Fat32CompatibilityTest(unittest.TestCase):
+  def setUp(self) -> None:
+    self.temporary_directory = tempfile.TemporaryDirectory()
+    self.root = Path(self.temporary_directory.name)
+
+  def tearDown(self) -> None:
+    self.temporary_directory.cleanup()
+
+  def test_layout_pads_small_fat32_and_uses_natural_large_size(self) -> None:
+    self.assertEqual(
+      usb_storage._nbdkit_layout(self.root),
+      (usb_storage.MIN_COMPATIBLE_DISK_SIZE, usb_storage.MIN_COMPATIBLE_DISK_SIZE),
+    )
+
+    boundary = self.root / "boundary.bin"
+    with boundary.open("wb") as sparse_file:
+      # The root directory consumes one cluster, so this puts the complete
+      # snapshot one cluster below the conservative FAT32 boundary.
+      sparse_file.truncate((usb_storage.FAT32_COMPATIBLE_DATA_CLUSTERS - 2) * usb_storage.FAT_CLUSTER_SIZE)
+    self.assertEqual(
+      usb_storage._nbdkit_layout(self.root),
+      (usb_storage.MIN_COMPATIBLE_DISK_SIZE, usb_storage.MIN_COMPATIBLE_DISK_SIZE),
+    )
+
+    with boundary.open("wb") as sparse_file:
+      sparse_file.truncate((usb_storage.FAT32_COMPATIBLE_DATA_CLUSTERS - 1) * usb_storage.FAT_CLUSTER_SIZE)
+    boundary_size, boundary_argument = usb_storage._nbdkit_layout(self.root)
+    boundary_fat_clusters = (usb_storage.FAT32_COMPATIBLE_DATA_CLUSTERS + 2 + 4095) // 4096
+    self.assertIsNone(boundary_argument)
+    self.assertEqual(
+      boundary_size,
+      (65 + 2 * boundary_fat_clusters + usb_storage.FAT32_COMPATIBLE_DATA_CLUSTERS) * usb_storage.FAT_CLUSTER_SIZE,
+    )
+
+    large = self.root / "large.hevc"
+    boundary.unlink()
+    with large.open("wb") as sparse_file:
+      sparse_file.truncate(3 * 1024**3)
+    used_clusters = usb_storage._snapshot_fat_data_size(self.root) // usb_storage.FAT_CLUSTER_SIZE
+    disk_size, size_argument = usb_storage._nbdkit_layout(self.root)
+    total_clusters = disk_size // usb_storage.FAT_CLUSTER_SIZE
+    fat_clusters = (used_clusters + 2 + 4095) // 4096
+
+    self.assertIsNone(size_argument)
+    self.assertGreater(disk_size, 3 * 1024**3)
+    self.assertEqual(total_clusters - 65 - 2 * fat_clusters, used_clusters)
+
+  def test_repairs_primary_backup_and_root_child_dotdot_idempotently(self) -> None:
+    image = self.root / "footage.img"
+    partition_offset, data_offset = make_nbdkit_fat32_image(image)
+
+    usb_storage._repair_fat32_image(image)
+    usb_storage._repair_fat32_image(image)
+
+    with image.open("rb") as repaired:
+      repaired.seek(partition_offset)
+      primary = repaired.read(usb_storage.SECTOR_SIZE)
+      repaired.seek(partition_offset + 6 * usb_storage.SECTOR_SIZE)
+      backup = repaired.read(usb_storage.SECTOR_SIZE)
+      repaired.seek(data_offset + usb_storage.FAT_CLUSTER_SIZE + 32)
+      dotdot = repaired.read(32)
+      repaired.seek(data_offset + 2 * usb_storage.FAT_CLUSTER_SIZE + 32)
+      nested_dotdot = repaired.read(32)
+    self.assertEqual(primary, backup)
+    self.assertEqual(primary[0:3], b"\xeb\x58\x90")
+    self.assertEqual(struct.unpack_from("<I", primary, 28)[0], 2048)
+    self.assertEqual(primary[64], 0x80)
+    self.assertEqual(struct.unpack_from("<H", dotdot, 20)[0], 0)
+    self.assertEqual(struct.unpack_from("<H", dotdot, 26)[0], 0)
+    self.assertEqual(struct.unpack_from("<H", nested_dotdot, 20)[0], 0)
+    self.assertEqual(struct.unpack_from("<H", nested_dotdot, 26)[0], 3)
+
+  def test_invalid_child_is_rejected_before_any_repair_write(self) -> None:
+    image = self.root / "footage.img"
+    partition_offset, data_offset = make_nbdkit_fat32_image(image)
+    with image.open("r+b") as malformed:
+      malformed.seek(data_offset + usb_storage.FAT_CLUSTER_SIZE)
+      malformed.write(b"X")
+
+    with self.assertRaisesRegex(usb_storage.StorageError, "dot entries"):
+      usb_storage._repair_fat32_image(image)
+
+    with image.open("rb") as unchanged:
+      unchanged.seek(partition_offset)
+      self.assertEqual(unchanged.read(3), bytes(3))
+
+
+class FakeProcess:
+  def __init__(self, *, pid: int = 4242, events: list[str] | None = None):
+    self.pid = pid
+    self.returncode: int | None = None
+    self.events = events if events is not None else []
+
+  def poll(self) -> int | None:
+    return self.returncode
+
+  def wait(self, timeout: float | None = None) -> int:
+    self.events.append("stop-child")
+    if self.returncode is None:
+      self.returncode = 0
+    return self.returncode
+
+  def terminate(self) -> None:
+    self.events.append("terminate-child")
+    self.returncode = -15
+
+  def kill(self) -> None:
+    self.events.append("kill-child")
+    self.returncode = -9
+
+
+class ManagerTestBase(unittest.TestCase):
+  def setUp(self) -> None:
+    self.temporary_directory = tempfile.TemporaryDirectory()
+    self.root = Path(self.temporary_directory.name)
+    self.source = self.root / "realdata"
+    self.source.mkdir()
+    self.snapshot = self.root / usb_storage.MANAGED_SNAPSHOT_NAME
+    self.mount = self.root / "run" / "usb-storage" / "footage.img"
+    self.lun = self.root / "config" / "lun.0" / "file"
+    self.lun.parent.mkdir(parents=True)
+    self.lun.write_text("\n")
+    (self.lun.parent / "ro").write_text("1\n")
+    (self.lun.parent / "removable").write_text("1\n")
+    self.udc_state = self.root / "udc-state"
+    self.udc_state.write_text("configured\n")
+    self.gadget_lock = self.root / "gadget.lock"
+
+  def tearDown(self) -> None:
+    if self.snapshot.exists():
+      usb_storage.SnapshotBuilder(self.source, self.snapshot).cleanup()
+    self.temporary_directory.cleanup()
+
+  def make_manager(self, **overrides: object) -> usb_storage.StorageManager:
+    arguments: dict[str, object] = {
+      "source": self.source,
+      "snapshot": self.snapshot,
+      "mount": self.mount,
+      "lun": self.lun,
+      "udc_state": self.udc_state,
+      "gadget_lock": self.gadget_lock,
+    }
+    arguments.update(overrides)
+    return usb_storage.StorageManager(**arguments)
+
+
+class StorageManagerTest(ManagerTestBase):
+  def test_nbdfuse_command_uses_cow_repair_and_exact_virtual_size(self) -> None:
+    captured: list[list[str]] = []
+    captured_environment: list[dict[str, str]] = []
+    repaired: list[Path] = []
+
+    def process_factory(command: list[str], **kwargs: object) -> FakeProcess:
+      captured.append(command)
+      captured_environment.append(kwargs["env"])  # type: ignore[arg-type]
+      process = FakeProcess()
+      self.mount.parent.mkdir(parents=True, exist_ok=True)
+      with self.mount.open("wb") as virtual_disk:
+        virtual_disk.truncate(usb_storage.MIN_COMPATIBLE_DISK_SIZE)
+      (self.mount.parent.with_suffix(".pid")).write_text(str(process.pid))
+      return process
+
+    manager = self.make_manager(process_factory=process_factory, image_repairer=repaired.append)
+    manager.snapshot_builder.build()
+    manager._start_export()
+
+    self.assertEqual(
+      captured[0],
+      [
+        "/usr/bin/nbdfuse",
+        "-P",
+        str(self.mount.parent.with_suffix(".pid")),
+        str(self.mount),
+        "--command",
+        "/usr/bin/nbdkit",
+        "-s",
+        "--exit-with-parent",
+        "--filter=cow",
+        "floppy",
+        f"dir={self.snapshot.resolve()}",
+        "label=COMMA",
+        f"size={usb_storage.MIN_COMPATIBLE_DISK_SIZE}",
+      ],
+    )
+    self.assertEqual(captured_environment[0]["TMPDIR"], str(manager.snapshot_builder.snapshot.parent))
+    self.assertEqual(repaired, [self.mount])
+    self.assertTrue(manager.export_started)
+
+  def test_nbdfuse_readiness_rejects_empty_or_unaligned_virtual_disk(self) -> None:
+    for invalid_size in (0, 513):
+      with self.subTest(invalid_size=invalid_size):
+        current_time = [0.0]
+
+        def process_factory(_command: list[str], *, size: int = invalid_size, **_kwargs: object) -> FakeProcess:
+          process = FakeProcess()
+          self.mount.parent.mkdir(parents=True, exist_ok=True)
+          with self.mount.open("wb") as virtual_disk:
+            virtual_disk.truncate(size)
+          self.mount.parent.with_suffix(".pid").write_text(str(process.pid))
+          return process
+
+        manager = self.make_manager(
+          process_factory=process_factory,
+          image_repairer=lambda _path: None,
+          ready_timeout=0.2,
+          poll_interval=0.1,
+          clock=lambda now=current_time: now[0],
+          sleep=lambda seconds, now=current_time: now.__setitem__(0, now[0] + seconds),
+        )
+        manager.snapshot_builder.build()
+
+        with self.assertRaisesRegex(usb_storage.StorageError, "readiness"):
+          manager._start_export()
+
+        manager.process = None
+        manager.export_started = False
+        self.mount.unlink()
+        manager.pidfile.unlink()
+
+  def test_lun_writes_require_existing_file_and_preserve_foreign_owner(self) -> None:
+    manager = self.make_manager()
+    manager._set_lun()
+    self.assertEqual(self.lun.read_text().strip(), str(self.mount))
+
+    self.lun.write_text("/some/other/backing.img\n")
+    with self.assertRaises(usb_storage.ForeignLunError):
+      manager._clear_lun()
+    self.assertEqual(self.lun.read_text().strip(), "/some/other/backing.img")
+    with self.assertRaises(usb_storage.StorageError):
+      manager._set_lun()
+
+    self.lun.unlink()
+    with self.assertRaises(usb_storage.StorageError):
+      manager._set_lun()
+    self.assertFalse(self.lun.exists())
+
+  def test_set_lun_requires_successful_readback(self) -> None:
+    class DroppingLunManager(usb_storage.StorageManager):
+      def _write_lun_unlocked(inner_self, _value: str) -> None:
+        pass
+
+    manager = DroppingLunManager(
+      source=self.source,
+      snapshot=self.snapshot,
+      mount=self.mount,
+      lun=self.lun,
+      udc_state=self.udc_state,
+      gadget_lock=self.gadget_lock,
+    )
+
+    with self.assertRaisesRegex(usb_storage.StorageError, "retain"):
+      manager._set_lun()
+
+  def test_set_lun_requires_read_only_removable_policy(self) -> None:
+    manager = self.make_manager()
+    for attribute in ("ro", "removable"):
+      with self.subTest(attribute=attribute):
+        (self.lun.parent / attribute).write_text("0\n")
+        with self.assertRaisesRegex(usb_storage.StorageError, attribute):
+          manager._set_lun()
+        self.assertEqual(self.lun.read_text().strip(), "")
+        (self.lun.parent / attribute).write_text("1\n")
+
+  def test_teardown_order_is_clear_unmount_stop_then_snapshot_remove(self) -> None:
+    events: list[str] = []
+
+    class OrderedManager(usb_storage.StorageManager):
+      def _clear_lun(inner_self) -> None:
+        events.append("clear-lun")
+        super()._clear_lun()
+
+    def command_runner(command: list[str], **_kwargs: object) -> types.SimpleNamespace:
+      self.assertEqual(command, ["/usr/bin/fusermount3", "-u", str(self.mount.parent)])
+      events.append("unmount")
+      try:
+        self.mount.unlink()
+      except FileNotFoundError:
+        pass
+      return types.SimpleNamespace(returncode=0)
+
+    manager = OrderedManager(
+      source=self.source,
+      snapshot=self.snapshot,
+      mount=self.mount,
+      lun=self.lun,
+      udc_state=self.udc_state,
+      gadget_lock=self.gadget_lock,
+      command_runner=command_runner,
+    )
+    segment = self.source / "00000001--abc123def0--0"
+    segment.mkdir()
+    (segment / "rlog.zst").write_bytes(b"data")
+    manager.snapshot_builder.build()
+    original_cleanup = manager.snapshot_builder.cleanup
+
+    def cleanup() -> None:
+      events.append("remove-snapshot")
+      original_cleanup()
+
+    manager.snapshot_builder.cleanup = cleanup  # type: ignore[method-assign]
+    self.mount.parent.mkdir(parents=True)
+    self.mount.touch()
+    manager.process = FakeProcess(events=events)
+    manager.export_started = True
+    manager._set_lun()
+
+    manager.teardown()
+
+    self.assertEqual(events, ["clear-lun", "unmount", "stop-child", "remove-snapshot"])
+    self.assertEqual(self.lun.read_text().strip(), "")
+    self.assertFalse(self.snapshot.exists())
+
+  def test_child_shutdown_escalates_with_finite_timeouts(self) -> None:
+    events: list[str] = []
+
+    class StubbornProcess(FakeProcess):
+      def wait(self, timeout: float | None = None) -> int:
+        events.append("wait")
+        if len([event for event in events if event == "wait"]) < 3:
+          raise subprocess.TimeoutExpired("nbdfuse", timeout)
+        self.returncode = -9
+        return self.returncode
+
+      def terminate(self) -> None:
+        events.append("terminate")
+
+      def kill(self) -> None:
+        events.append("kill")
+
+    manager = self.make_manager(stop_timeout=0.25)
+    manager.process = StubbornProcess()
+    manager._stop_child()
+
+    self.assertEqual(events, ["wait", "terminate", "wait", "kill", "wait"])
+
+  def test_lun_clear_retries_busy_until_kernel_releases_media(self) -> None:
+    current_time = [0.0]
+
+    class BusyManager(usb_storage.StorageManager):
+      attempts = 0
+
+      def _write_lun_unlocked(inner_self, value: str) -> None:
+        if value == "":
+          inner_self.attempts += 1
+          if inner_self.attempts < 3:
+            raise OSError(errno.EBUSY, "host prevents media removal")
+        super()._write_lun_unlocked(value)
+
+    manager = BusyManager(
+      source=self.source,
+      snapshot=self.snapshot,
+      mount=self.mount,
+      lun=self.lun,
+      udc_state=self.udc_state,
+      gadget_lock=self.gadget_lock,
+      stop_timeout=1.0,
+      poll_interval=0.1,
+      clock=lambda: current_time[0],
+      sleep=lambda seconds: current_time.__setitem__(0, current_time[0] + seconds),
+    )
+    self.lun.write_text(f"{self.mount}\n")
+
+    manager._clear_lun()
+
+    self.assertEqual(manager.attempts, 3)
+    self.assertEqual(self.lun.read_text().strip(), "")
+
+  def test_teardown_leaves_export_alive_when_lun_cannot_be_cleared(self) -> None:
+    events: list[str] = []
+
+    class RefusingManager(usb_storage.StorageManager):
+      def _clear_lun(inner_self) -> None:
+        events.append("clear-lun")
+        raise usb_storage.StorageError("busy")
+
+      def _unmount(inner_self) -> None:
+        events.append("unsafe-unmount")
+
+    manager = RefusingManager(
+      source=self.source,
+      snapshot=self.snapshot,
+      mount=self.mount,
+      lun=self.lun,
+      udc_state=self.udc_state,
+      gadget_lock=self.gadget_lock,
+    )
+    manager.snapshot_builder.build()
+    manager.process = FakeProcess(events=events)
+    manager.export_started = True
+
+    with self.assertRaisesRegex(usb_storage.StorageError, "attached LUN"):
+      manager.teardown()
+
+    self.assertEqual(events, ["clear-lun"])
+    self.assertIsNotNone(manager.process)
+    self.assertTrue(self.snapshot.exists())
+
+  def test_busy_lun_fallback_preserves_full_teardown_and_rebind_order(self) -> None:
+    events: list[str] = []
+
+    class FallbackManager(usb_storage.StorageManager):
+      clear_attempts = 0
+
+      def _clear_lun(inner_self) -> None:
+        inner_self.clear_attempts += 1
+        events.append("clear-lun")
+        if inner_self.clear_attempts == 1:
+          raise usb_storage.LunBusyError("prevented")
+
+      def _run_gadget_helper(inner_self, action: str) -> None:
+        events.append(action)
+
+      def _unmount(inner_self) -> None:
+        events.append("unmount")
+
+      def _stop_child(inner_self) -> None:
+        events.append("stop-child")
+        inner_self.process = None
+        inner_self.export_started = False
+
+    manager = FallbackManager(
+      source=self.source,
+      snapshot=self.snapshot,
+      mount=self.mount,
+      lun=self.lun,
+      udc_state=self.udc_state,
+      gadget_lock=self.gadget_lock,
+    )
+    manager.snapshot_builder.build()
+    original_cleanup = manager.snapshot_builder.cleanup
+
+    def cleanup() -> None:
+      events.append("remove-snapshot")
+      original_cleanup()
+
+    manager.snapshot_builder.cleanup = cleanup  # type: ignore[method-assign]
+    manager.process = FakeProcess()
+    manager.export_started = True
+
+    manager.teardown()
+
+    self.assertEqual(
+      events,
+      ["clear-lun", "unbind", "clear-lun", "unmount", "stop-child", "remove-snapshot", "bind"],
+    )
+    self.assertFalse(manager.forced_unbound)
+
+  def test_nonzero_unmount_is_fail_closed(self) -> None:
+    events: list[str] = []
+
+    def failing_unmount(command: list[str], **_kwargs: object) -> types.SimpleNamespace:
+      events.append("unmount")
+      self.assertEqual(command, ["/usr/bin/fusermount3", "-u", str(self.mount.parent)])
+      return types.SimpleNamespace(returncode=1)
+
+    manager = self.make_manager(command_runner=failing_unmount)
+    manager.snapshot_builder.build()
+    manager.process = FakeProcess(events=events)
+    manager.export_started = True
+    self.lun.write_text(f"{self.mount}\n")
+
+    with self.assertRaisesRegex(usb_storage.StorageError, "fusermount3"):
+      manager.teardown()
+
+    self.assertEqual(events, ["unmount"])
+    self.assertIsNotNone(manager.process)
+    self.assertTrue(self.snapshot.exists())
+
+  def test_prepare_mount_removes_only_exact_stale_runtime_files(self) -> None:
+    manager = self.make_manager()
+    self.mount.parent.mkdir(parents=True)
+    self.mount.write_text("stale virtual file")
+    manager.pidfile.write_text("999")
+    unrelated = self.mount.parent / "keep-me"
+    unrelated.write_text("keep")
+
+    manager._prepare_mount()
+
+    self.assertFalse(self.mount.exists())
+    self.assertFalse(manager.pidfile.exists())
+    self.assertEqual(unrelated.read_text(), "keep")
+
+
+class ScriptedMonitorManager(usb_storage.StorageManager):
+  def __init__(self, *, udc_states: list[str], lun_values: list[str], **kwargs: object):
+    self._udc_states = iter(udc_states)
+    self._lun_values = iter(lun_values)
+    self._last_udc = udc_states[-1]
+    self._last_lun = lun_values[-1] if lun_values else ""
+    super().__init__(**kwargs)
+    self.process = FakeProcess()
+
+  def _read_udc_state(self) -> str:
+    try:
+      self._last_udc = next(self._udc_states)
+    except StopIteration:
+      pass
+    return self._last_udc
+
+  def _read_lun(self) -> str:
+    try:
+      self._last_lun = next(self._lun_values)
+    except StopIteration:
+      pass
+    return self._last_lun
+
+
+class StorageMonitorTest(ManagerTestBase):
+  def scripted_manager(
+    self,
+    *,
+    udc_states: list[str],
+    lun_values: list[str],
+    sleep: object | None = None,
+  ) -> ScriptedMonitorManager:
+    healthy_filesystem = types.SimpleNamespace(
+      f_bavail=20 * 1024**3 // 4096,
+      f_frsize=4096,
+      f_blocks=100 * 1024**3 // 4096,
+    )
+    return ScriptedMonitorManager(
+      source=self.source,
+      snapshot=self.snapshot,
+      mount=self.mount,
+      lun=self.lun,
+      udc_state=self.udc_state,
+      gadget_lock=self.gadget_lock,
+      udc_states=udc_states,
+      lun_values=lun_values,
+      sleep=sleep or (lambda _seconds: None),
+      filesystem_stats=lambda _path: healthy_filesystem,
+    )
+
+  def test_detects_host_eject(self) -> None:
+    manager = self.scripted_manager(
+      udc_states=["configured"],
+      lun_values=[str(self.mount), ""],
+    )
+
+    self.assertEqual(manager.monitor(threading.Event()), usb_storage.SessionEnd.EJECTED)
+
+  def test_detects_detach_after_configuration(self) -> None:
+    manager = self.scripted_manager(
+      udc_states=["configured", "not attached"],
+      lun_values=[str(self.mount)],
+    )
+
+    self.assertEqual(manager.monitor(threading.Event()), usb_storage.SessionEnd.DETACHED)
+
+  def test_low_space_ends_session(self) -> None:
+    stats = types.SimpleNamespace(
+      f_bavail=usb_storage.MIN_FREE_BYTES // 4096,
+      f_frsize=4096,
+      f_blocks=10 * (usb_storage.MIN_FREE_BYTES // 4096),
+    )
+    manager = self.scripted_manager(
+      udc_states=["configured"],
+      lun_values=[str(self.mount)],
+    )
+    manager.filesystem_stats = lambda _path: stats
+
+    self.assertEqual(manager.monitor(threading.Event()), usb_storage.SessionEnd.LOW_SPACE)
+
+  def test_space_stat_failure_is_fail_closed(self) -> None:
+    manager = self.scripted_manager(
+      udc_states=["configured"],
+      lun_values=[str(self.mount)],
+    )
+    manager.filesystem_stats = lambda _path: (_ for _ in ()).throw(OSError("statvfs failed"))
+
+    self.assertEqual(manager.monitor(threading.Event()), usb_storage.SessionEnd.LOW_SPACE)
+
+  def test_wait_for_attach_is_idle_until_stopped(self) -> None:
+    stop_event = threading.Event()
+    manager = self.scripted_manager(
+      udc_states=["attached"],
+      lun_values=[str(self.mount)],
+      sleep=lambda _seconds: stop_event.set(),
+    )
+
+    self.assertFalse(manager._wait_for_configured(stop_event))
+
+  def test_run_does_not_build_snapshot_before_attach(self) -> None:
+    stop_event = threading.Event()
+    self.udc_state.write_text("not attached\n")
+    self.snapshot.mkdir()
+    (self.snapshot / "stale-link").write_bytes(b"stale")
+    manager = self.make_manager(sleep=lambda _seconds: stop_event.set())
+    self.mount.parent.mkdir(parents=True)
+    self.mount.write_text("stale virtual file")
+    manager.pidfile.write_text("999")
+
+    self.assertEqual(manager.run(stop_event), 0)
+    self.assertFalse(self.snapshot.exists())
+    self.assertFalse(self.mount.exists())
+    self.assertFalse(manager.pidfile.exists())
+
+  def test_missing_realdata_at_service_start_is_not_fatal(self) -> None:
+    self.source.rmdir()
+    stop_event = threading.Event()
+    manager = self.make_manager(sleep=lambda _seconds: stop_event.set())
+
+    self.assertFalse(manager._wait_for_source_while_attached(stop_event))
+    self.assertFalse(self.snapshot.exists())
+
+  def test_eject_and_low_space_latch_before_reinsertion(self) -> None:
+    events: list[str] = []
+    stop_event = threading.Event()
+
+    class LifecycleManager(usb_storage.StorageManager):
+      wait_count = 0
+      session_ends = iter((usb_storage.SessionEnd.EJECTED, usb_storage.SessionEnd.LOW_SPACE))
+
+      def _wait_for_configured(inner_self, event: threading.Event) -> bool:
+        inner_self.wait_count += 1
+        events.append("wait-configured")
+        if inner_self.wait_count <= 2:
+          return True
+        event.set()
+        return False
+
+      def _wait_for_source_while_attached(inner_self, _event: threading.Event) -> bool:
+        events.append("source-ready")
+        return True
+
+      def _read_udc_state(inner_self) -> str:
+        return "configured"
+
+      def _start_export(inner_self) -> None:
+        events.append("start-export")
+
+      def _set_lun(inner_self) -> None:
+        events.append("set-lun")
+
+      def monitor(inner_self, _event: threading.Event) -> usb_storage.SessionEnd:
+        end = next(inner_self.session_ends)
+        events.append(f"monitor-{end}")
+        return end
+
+      def teardown(inner_self, *, rebind: bool = True) -> None:
+        events.append("teardown")
+        inner_self.snapshot_builder.cleanup()
+
+      def _wait_for_physical_detach(inner_self, _event: threading.Event) -> bool:
+        events.append("eject-latch-until-detach")
+        return True
+
+    manager = LifecycleManager(
+      source=self.source,
+      snapshot=self.snapshot,
+      mount=self.mount,
+      lun=self.lun,
+      udc_state=self.udc_state,
+      gadget_lock=self.gadget_lock,
+      snapshot_wall_clock_ns=lambda: time.time_ns() + (3 * usb_storage.DEFAULT_STABILITY_AGE_NS),
+    )
+    segment = self.source / "00000001--abc123def0--0"
+    segment.mkdir()
+    (segment / "qlog.zst").write_bytes(b"data")
+
+    self.assertEqual(manager.run(stop_event), 2)
+    self.assertEqual(events.count("start-export"), 2)
+    self.assertEqual(events.count("set-lun"), 2)
+    self.assertEqual(events.count("teardown"), 2)
+    self.assertEqual(events.count("eject-latch-until-detach"), 2)
+    first_teardown = events.index("teardown")
+    latch = events.index("eject-latch-until-detach")
+    second_start = events.index("start-export", first_teardown + 1)
+    self.assertLess(first_teardown, latch)
+    self.assertLess(latch, second_start)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/userspace/tests/test_usb_storage.py
+++ b/userspace/tests/test_usb_storage.py
@@ -569,6 +569,31 @@ class StorageManagerTest(ManagerTestBase):
 
     self.assertEqual(commands, [])
 
+  def test_manager_can_only_request_validated_storage_reenumeration(self) -> None:
+    commands: list[tuple[list[str], float]] = []
+
+    def runner(command: list[str], **kwargs: object) -> types.SimpleNamespace:
+      commands.append((command, kwargs["timeout"]))  # type: ignore[arg-type]
+      return types.SimpleNamespace(returncode=0)
+
+    manager = self.make_manager(command_runner=runner, stop_timeout=3.0)
+
+    manager._run_gadget_helper("reenumerate-managed-storage")
+
+    self.assertEqual(
+      commands,
+      [(["/usr/comma/usb_gadget.sh", "reenumerate-managed-storage"], 3.0)],
+    )
+
+  def test_gadget_helper_timeout_is_reported_as_storage_error(self) -> None:
+    def runner(command: list[str], **kwargs: object) -> object:
+      raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+    manager = self.make_manager(command_runner=runner)
+
+    with self.assertRaisesRegex(usb_storage.StorageError, "re-enumerate|reenumerate|timed out"):
+      manager._run_gadget_helper("reenumerate-managed-storage")
+
   def test_nbdkit_probe_requires_exact_supported_floppy_and_cow(self) -> None:
     command: list[str] = []
 
@@ -933,13 +958,20 @@ class StorageManagerTest(ManagerTestBase):
 
   def test_nonzero_unmount_is_fail_closed(self) -> None:
     events: list[str] = []
+    current_time = [0.0]
 
     def failing_unmount(command: list[str], **_kwargs: object) -> types.SimpleNamespace:
       events.append("unmount")
       self.assertEqual(command, ["/usr/bin/fusermount3", "-u", str(self.mount.parent)])
       return types.SimpleNamespace(returncode=1)
 
-    manager = self.make_manager(command_runner=failing_unmount)
+    manager = self.make_manager(
+      command_runner=failing_unmount,
+      stop_timeout=0.25,
+      poll_interval=0.1,
+      clock=lambda: current_time[0],
+      sleep=lambda seconds: current_time.__setitem__(0, current_time[0] + seconds),
+    )
     manager.snapshot_builder.build()
     manager.process = FakeProcess(events=events)
     manager.export_started = True
@@ -948,9 +980,36 @@ class StorageManagerTest(ManagerTestBase):
     with self.assertRaisesRegex(usb_storage.StorageError, "fusermount3"):
       manager.teardown()
 
-    self.assertEqual(events, ["unmount"])
+    self.assertEqual(events, ["unmount", "unmount", "unmount"])
     self.assertIsNotNone(manager.process)
     self.assertTrue(self.snapshot.exists())
+
+  def test_unmount_retries_transient_busy_before_continuing_teardown(self) -> None:
+    events: list[str] = []
+    current_time = [0.0]
+
+    def transient_unmount(command: list[str], **_kwargs: object) -> types.SimpleNamespace:
+      self.assertEqual(command, ["/usr/bin/fusermount3", "-u", str(self.mount.parent)])
+      events.append("unmount")
+      return types.SimpleNamespace(returncode=1 if len(events) < 3 else 0)
+
+    manager = self.make_manager(
+      command_runner=transient_unmount,
+      stop_timeout=1.0,
+      poll_interval=0.1,
+      clock=lambda: current_time[0],
+      sleep=lambda seconds: current_time.__setitem__(0, current_time[0] + seconds),
+    )
+    manager.snapshot_builder.build()
+    manager.process = FakeProcess(events=events)
+    manager.export_started = True
+    self.lun.write_text(f"{self.mount}\n")
+
+    self.assertFalse(manager.teardown())
+
+    self.assertEqual(events, ["unmount", "unmount", "unmount", "stop-child"])
+    self.assertFalse(manager.export_started)
+    self.assertFalse(self.snapshot.exists())
 
   def test_prepare_mount_removes_only_exact_stale_runtime_files(self) -> None:
     manager = self.make_manager()
@@ -1024,6 +1083,72 @@ class StorageMonitorTest(ManagerTestBase):
     )
 
     self.assertEqual(manager.monitor(threading.Event()), usb_storage.SessionEnd.EJECTED)
+
+  def test_reenumeration_waits_for_configured_before_monitoring(self) -> None:
+    current_time = [0.0]
+    sleeps: list[float] = []
+    commands: list[str] = []
+
+    def sleep(seconds: float) -> None:
+      sleeps.append(seconds)
+      current_time[0] += seconds
+
+    manager = self.scripted_manager(
+      udc_states=["not attached", "addressed", "configured"],
+      lun_values=[str(self.mount)],
+      sleep=sleep,
+    )
+    manager.clock = lambda: current_time[0]
+    manager.command_runner = lambda command, **_kwargs: (
+      commands.append(command[-1]) or types.SimpleNamespace(returncode=0)
+    )
+
+    self.assertIsNone(manager._reenumerate_media(threading.Event()))
+    self.assertEqual(commands, ["reenumerate-managed-storage"])
+    self.assertEqual(sleeps, [0.1, 0.1])
+
+  def test_reenumeration_wait_is_bounded_when_host_never_configures(self) -> None:
+    current_time = [0.0]
+    sleeps: list[float] = []
+
+    def sleep(seconds: float) -> None:
+      sleeps.append(seconds)
+      current_time[0] += seconds
+
+    manager = self.scripted_manager(
+      udc_states=["attached"],
+      lun_values=[str(self.mount)],
+      sleep=sleep,
+    )
+    manager.clock = lambda: current_time[0]
+    manager.ready_timeout = 0.25
+    manager.command_runner = lambda _command, **_kwargs: types.SimpleNamespace(returncode=0)
+
+    with self.assertRaisesRegex(usb_storage.StorageError, "re-enumeration"):
+      manager._reenumerate_media(threading.Event())
+
+    self.assertEqual(sleeps[:2], [0.1, 0.1])
+    self.assertEqual(len(sleeps), 3)
+    self.assertAlmostEqual(sleeps[2], 0.05)
+    self.assertAlmostEqual(current_time[0], 0.25)
+
+  def test_reenumeration_observes_early_eject_and_stop(self) -> None:
+    commands: list[str] = []
+    manager = self.scripted_manager(
+      udc_states=["configured"],
+      lun_values=[""],
+    )
+    manager.command_runner = lambda command, **_kwargs: (
+      commands.append(command[-1]) or types.SimpleNamespace(returncode=0)
+    )
+
+    self.assertEqual(manager._reenumerate_media(threading.Event()), usb_storage.SessionEnd.EJECTED)
+    self.assertEqual(commands, ["reenumerate-managed-storage"])
+
+    stop_event = threading.Event()
+    stop_event.set()
+    self.assertEqual(manager._reenumerate_media(stop_event), usb_storage.SessionEnd.STOPPED)
+    self.assertEqual(commands, ["reenumerate-managed-storage"])
 
   def test_detects_detach_after_configuration(self) -> None:
     manager = self.scripted_manager(
@@ -1230,6 +1355,10 @@ class StorageMonitorTest(ManagerTestBase):
       def _set_lun(inner_self) -> None:
         events.append("set-lun")
 
+      def _reenumerate_media(inner_self, _event: threading.Event) -> usb_storage.SessionEnd | None:
+        events.append("reenumerate-media")
+        return None
+
       def monitor(inner_self, _event: threading.Event) -> usb_storage.SessionEnd:
         events.append("monitor-detached")
         return usb_storage.SessionEnd.DETACHED
@@ -1277,6 +1406,7 @@ class StorageMonitorTest(ManagerTestBase):
         "source-ready",
         "start-export",
         "set-lun",
+        "reenumerate-media",
         "monitor-detached",
         "teardown",
         "wait-configured",
@@ -1341,6 +1471,10 @@ class StorageMonitorTest(ManagerTestBase):
       def _set_lun(inner_self) -> None:
         events.append("set-lun")
 
+      def _reenumerate_media(inner_self, _event: threading.Event) -> usb_storage.SessionEnd | None:
+        events.append("reenumerate-media")
+        return None
+
       def monitor(inner_self, _event: threading.Event) -> usb_storage.SessionEnd:
         end = next(inner_self.session_ends)
         events.append(f"monitor-{end}")
@@ -1370,6 +1504,7 @@ class StorageMonitorTest(ManagerTestBase):
     self.assertEqual(manager.run(stop_event), 2)
     self.assertEqual(events.count("start-export"), 2)
     self.assertEqual(events.count("set-lun"), 2)
+    self.assertEqual(events.count("reenumerate-media"), 2)
     self.assertEqual(events.count("teardown"), 2)
     self.assertEqual(events.count("eject-latch-until-detach"), 2)
     first_teardown = events.index("teardown")

--- a/userspace/tests/test_usb_storage.py
+++ b/userspace/tests/test_usb_storage.py
@@ -14,6 +14,7 @@ import threading
 import time
 import types
 import unittest  # noqa: TID251 - these tests intentionally use only the standard library
+from unittest import mock
 
 
 COMMA_DIR = Path(__file__).parents[1] / "root" / "usr" / "comma"
@@ -104,15 +105,26 @@ class SnapshotBuilderTest(unittest.TestCase):
     self.assertIn("non-regular", reasons[fifo_segment.name])
     self.assertEqual(list(self.snapshot.iterdir()), [])
 
-  def test_empty_file_excludes_entire_segment(self) -> None:
+  def test_empty_file_is_omitted_without_hiding_usable_footage(self) -> None:
     segment = self.make_segment("00000001--abc123def0--0")
     (segment / "rlog.zst").write_bytes(b"complete log")
     (segment / "empty.hevc").touch()
 
     result = self.builder().build()
 
+    self.assertEqual(result.included, (segment.name,))
+    self.assertEqual(result.excluded, ())
+    self.assertEqual((self.snapshot / segment.name / "rlog.zst").read_bytes(), b"complete log")
+    self.assertFalse((self.snapshot / segment.name / "empty.hevc").exists())
+
+  def test_segment_with_only_empty_files_is_excluded(self) -> None:
+    segment = self.make_segment("00000001--abc123def0--0")
+    (segment / "empty.hevc").touch()
+
+    result = self.builder().build()
+
     self.assertEqual(result.included, ())
-    self.assertIn("empty file unsupported", result.excluded[0][1])
+    self.assertIn("no exportable non-empty files", result.excluded[0][1])
     self.assertFalse((self.snapshot / segment.name).exists())
 
   def test_unrelated_and_nested_directories_are_ignored(self) -> None:
@@ -156,6 +168,28 @@ class SnapshotBuilderTest(unittest.TestCase):
       with self.subTest(valid_name=name):
         usb_storage._validate_portable_name(name)
 
+  def test_portable_name_key_folds_case_and_unicode_normalization(self) -> None:
+    self.assertEqual(usb_storage._portable_name_key("RLOG.ZST"), usb_storage._portable_name_key("rlog.zst"))
+    self.assertEqual(usb_storage._portable_name_key("é.txt"), usb_storage._portable_name_key("e\u0301.txt"))
+
+  def test_colliding_sibling_names_exclude_entire_segment(self) -> None:
+    segment = self.make_segment("00000001--abc123def0--0")
+    first = segment / "first.zst"
+    second = segment / "second.zst"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    real_key = usb_storage._portable_name_key
+
+    def force_fixture_collision(name: str) -> str:
+      return "fixture-collision" if name in (first.name, second.name) else real_key(name)
+
+    with mock.patch.object(usb_storage, "_portable_name_key", side_effect=force_fixture_collision):
+      result = self.builder().build()
+
+    self.assertEqual(result.included, ())
+    self.assertIn("FAT/Windows-colliding", result.excluded[0][1])
+    self.assertFalse((self.snapshot / segment.name).exists())
+
   def test_unsafe_component_excludes_entire_segment(self) -> None:
     segment = self.make_segment("00000001--abc123def0--0")
     (segment / "CON.txt").write_bytes(b"reserved name")
@@ -185,6 +219,15 @@ class SnapshotBuilderTest(unittest.TestCase):
     self.assertEqual(result.included, (portable_name,))
     self.assertEqual((self.snapshot / portable_name / "rlog.zst").read_bytes(), b"legacy route")
     self.assertFalse((self.snapshot / segment.name).exists())
+
+  def test_historical_bare_timestamp_segment_is_exported(self) -> None:
+    segment = self.make_segment("2022-11-06--19-00-19--79")
+    (segment / "rlog.zst").write_bytes(b"historical route")
+
+    result = self.builder().build()
+
+    self.assertEqual(result.included, (segment.name,))
+    self.assertEqual((self.snapshot / segment.name / "rlog.zst").read_bytes(), b"historical route")
 
   def test_portable_segment_name_collision_excludes_both_sources(self) -> None:
     legacy = self.make_segment("a2a0ccea32023010|2026-08-23--12-34-56--0")


### PR DESCRIPTION
## Summary

Adds driverless, read-only USB Mass Storage access to completed openpilot footage on comma 3X/four.

Fixes commaai/openpilot#38291 ($300 bounty).

The implementation is ready for review. A comma-assigned storage-only USB identity and Windows validation remain acceptance blockers.

## Approach

The live userdata partition remains mounted as ext4 and is never exposed to the host. A new system service instead:

- waits for a normal power-first USB host connection;
- selects completed, stable `realdata` segments and rejects active or unsafe trees;
- hard-links selected files into a private per-session snapshot on the same filesystem;
- synthesizes a FAT32 disk from that snapshot with Ubuntu Noble's `nbdkit-floppy` and COW filter;
- repairs the small set of nbdkit 1.36 FAT32 metadata fields needed by native host readers; and
- attaches the resulting regular file to a removable, read-only configfs mass-storage LUN.

The hard-link snapshot freezes the exported namespace and keeps an inode readable if loggerd's deleter unlinks its original name. It does not make file contents immutable, so `.lock` exclusion, an age threshold, two matching scans, and a final pre-export layout check enforce the completed-file invariant. A free-space guard 1 GiB / 1 percentage point above loggerd's 5 GiB / 10% floor ejects and removes the snapshot before pinned files can exhaust userdata.

The gadget lifecycle is serialized through a root-owned lock. Teardown is ordered as LUN clear, FUSE unmount, exporter stop, then snapshot cleanup. A post-stop recovery path removes only an exactly identified dead `nbdfuse` mount and managed snapshot after systemd has killed the service cgroup. Host eject, physical detach, forced service stop, stale runtime state, `PREVENT MEDIUM REMOVAL`, and low-space events fail closed.

## USB integration

- Refactors `set_adb.sh` through one serialized configfs helper.
- With ADB enabled, preserves NCM at MI_00/01 and ADB at MI_02, then appends mass storage at MI_03 under the existing identity.
- With ADB disabled, exposes mass storage only. This personality intentionally refuses to bind until comma supplies a separate owner-approved VID/PID, avoiding Windows driver-cache collisions from reusing interface IDs under `04d8:1234`.
- Adds `usb-storage.service`, ordered shutdown handling, required Noble packages, root-owned lock creation, and service enablement.
- Re-enumerates only after validating the exact requested personality, single config, single LUN, backing path, and read-only policy. Unexpected configurations or LUNs are preserved but left unbound.

## Safety and privacy boundaries

- Exports `realdata` only; no params, credentials, openpilot checkout, or raw userdata blocks.
- Host writes are rejected by the kernel LUN (`ro=1`); the backing export is COW-isolated.
- Segments with active `.lock` files, unstable metadata, symlinks, special files, unsafe FAT/Windows names, case/NFC collisions, or FAT32-oversized files are excluded.
- Empty artifacts are omitted because Noble nbdkit 1.36 emits an invalid FAT chain for them; usable sibling footage remains available.
- Historical timestamp, current log-ID, and canonical/copied route-directory forms are supported. Legacy `|` is mapped to openpilot's Windows-safe `_` representation in the snapshot only.
- No live-control, panda safety, vehicle, camera, bootloader, or partition behavior is changed.

## Validation

Software:

- `python3 -m unittest discover -s userspace/tests -p 'test_*.py' -v` — 125/125 passed on the clean PR tree.
- Ruff, `py_compile`, shell syntax, and `git diff --check` — passed.
- The ARM workflow runs the production snapshot/layout/repair code against installed Noble `nbdkit 1.36.3`, then verifies padded and natural-size images with `fsck.fat`, mtools extraction, matching hashes, and a multi-cluster FAT root containing 172 route directories.
- Upstream PR run [`32665270834`](https://github.com/commaai/agnos-builder/actions/runs/32665270834) — passed 125/125 tests, padded/natural/multi-cluster-root installed-Noble FAT integration, kernel build, full system build, and filesystem statistics at exact head `5ca14c2`.

comma four bench validation, without flashing:

- Kept the device on its original successful AGNOS 18.4 slot. The built target root was mounted read-only with `norecovery` and used as a chroot on the common device kernel; no updater, A/B write, camera node, real route, or vehicle was used.
- macOS: 20/20 native enumerate, FAT32 browse, six-file copy/hash, write-denial, eject, and re-enumeration cycles passed. The 19 between-cycle disconnects were deliberate configfs disconnects, not physical cable pulls.
- Ubuntu 24.04 ARM: 1/1 native enumerate, UTF-8 FAT32 browse, six-file copy/hash, write-denial, and eject passed after a real port-1 unplug/replug while port 2 remained powered.
- Final cleanup restored the stock AGNOS 18.4 NCM+ADB gadget. No stale LUN, FUSE mount, or exporter process remained, and no ext4/journal/kernel error was observed.

## Acceptance status / blockers

- [x] comma four hardware path exercised with port 2 powered before port 1 host data.
- [x] macOS uses its inbox storage/FAT driver and copies verified files.
- [x] Linux uses its inbox storage/FAT driver and copies verified files.
- [x] Host write access is denied.
- [x] Repeated macOS sessions and one physical Linux reconnect/eject recover cleanly.
- [ ] Windows native enumeration and File Explorer copy still need to be run.
- [ ] A distinct owner-approved storage-only VID/PID is required before ADB-off mode can bind.
- [ ] The exact target image was not booted; validation used its userspace read-only on the live common kernel, so target systemd boot ordering is not claimed.

## Known limitations

- FAT32 cannot represent an individual file of 4 GiB or larger; a segment containing one is excluded. Normal one-minute route files are far below this limit.
- The volume is a point-in-time read-only view built at host attachment. New segments appear after the next physical reconnect.
- Zero-byte files contain no retrievable payload and are omitted due to the Noble plugin bug described above.
