### PR TITLE
fix soundd init race

### DIFF
--- a/userspace/services.sh
+++ b/userspace/services.sh
@@ -58,6 +58,8 @@ systemctl disable multipathd.socket
 systemctl disable chgrp-diag.service
 systemctl disable lvm2-monitor.service
 systemctl mask systemd-backlight@.service
+systemctl mask alsa-restore.service
+ln -s /dev/null /etc/udev/rules.d/90-alsa-restore.rules
 systemctl disable dpkg-db-backup.timer
 systemctl disable ua-reboot-cmds.service
 systemctl disable ubuntu-advantage.service


### PR DESCRIPTION
AGNOS initializes sound in sound.service, the redundant ALSA restore races with sound initialization and can prevent micd and soundd from starting.