### PR TITLE
tizi: use minimal audio initialization

### DIFF
--- a/userspace/root/usr/comma/comma-init.sh
+++ b/userspace/root/usr/comma/comma-init.sh
@@ -218,7 +218,6 @@ function init_sound (
     /usr/comma/sound/tinymix set "MultiMedia1 Mixer SEC_MI2S_TX" 1
   else
     /usr/comma/sound/tinymix set "MultiMedia1 Mixer TERT_MI2S_TX" 1
-    /usr/comma/sound/tinymix set "TERT_MI2S_TX Channels" Two
   fi
 )
 


### PR DESCRIPTION
## Summary

Update the AGNOS kernel to the paired tizi boot-time optimization and stop setting `TERT_MI2S_TX Channels` through `tinymix`.

The minimal tizi sound card intentionally skips the heavyweight codec-control registration. Its machine driver now sets tertiary capture to two channels directly, so the removed mixer command is redundant and its control is no longer exposed.

## Verification

- paired kernel commit passes a complete `./build_kernel.sh`
- the build produced the comma 3X device tree and signed 45 MB boot image
- `git diff --check` passed

Depends on: https://github.com/commaai/agnos-kernel-sdm845/pull/139

Related: commaai/openpilot#30894